### PR TITLE
Add position argument to Header for top/bottom placement

### DIFF
--- a/public/docs/3-components/header.gjs.md
+++ b/public/docs/3-components/header.gjs.md
@@ -52,30 +52,27 @@ pnpm add nvp.ui
 import { ComponentSignature } from "kolay";
 
 <template>
-  <ComponentSignature
-    @package="."
-    @module="declarations/components/header.gts"
-    @name="Signature"
-  />
+  <ComponentSignature @package="." @module="declarations/components/header" @name="Signature" />
 </template>
 ```
 
 ### State Attributes
 
-| key | description |
-| :---: | :--- |
+|       key       | description                                                |
+| :-------------: | :--------------------------------------------------------- |
 | `data-position` | Set to "top" or "bottom" based on the `@position` argument |
 
 ### Styling
 
 Public selectors:
 
-| key | description |
-| :---: | :--- |
-| `.preem__header` | The header element |
-| `.preem__header__left` | Container for left-aligned content |
+|           key           | description                         |
+| :---------------------: | :---------------------------------- |
+|    `.preem__header`     | The header element                  |
+| `.preem__header__left`  | Container for left-aligned content  |
 | `.preem__header__right` | Container for right-aligned content |
 
 The header uses `position: sticky` by default with:
+
 - `top: 0` for default or `@position="top"`
 - `bottom: 0` for `@position="bottom"`

--- a/public/docs/3-components/header.gjs.md
+++ b/public/docs/3-components/header.gjs.md
@@ -4,39 +4,97 @@ The `<Header />` component provides a navigation bar for your application that c
 
 This component is ideal for app navigation, offering a clean and flexible layout with left and right content areas.
 
-```gjs live
+```gjs live no-shadow
 import { Header } from "nvp.ui";
 
 <template>
-  <Header>
-    <:left>
-      <a href="/">nvp.ui</a>
-    </:left>
-    <:right>
-      <a href="/about">About</a>
-      <a href="/contact">Contact</a>
-    </:right>
-  </Header>
+  <div class="scroll-container">
+    <Header>
+      <:left>
+        <a href="/">nvp.ui</a>
+      </:left>
+      <:right>
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
+      </:right>
+    </Header>
+
+    <div class="scroll-content">
+      <p>Scroll down to see the header stick to the top.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit.</p>
+      <p>Excepteur sint occaecat cupidatat non proident.</p>
+    </div>
+  </div>
+
+  <style>
+    @scope {
+      .scroll-container {
+        height: 12rem;
+        overflow-y: auto;
+        border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.1));
+        border-radius: 0.5rem;
+      }
+      .scroll-content {
+        padding: 1rem;
+      }
+      .scroll-content p {
+        margin: 1.5rem 0;
+        color: light-dark(#666, #aaa);
+      }
+    }
+  </style>
 </template>
 ```
 
 ## Bottom Positioning
 
-The header can also be positioned at the bottom of the screen by setting `@position="bottom"`:
+Use `@position="bottom"` to stick the header to the bottom. Scroll this container to see it stay anchored:
 
-```gjs live
+```gjs live no-shadow
 import { Header } from "nvp.ui";
 
 <template>
-  <Header @position="bottom">
-    <:left>
-      <span>Footer Navigation</span>
-    </:left>
-    <:right>
-      <a href="/about">About</a>
-      <a href="/contact">Contact</a>
-    </:right>
-  </Header>
+  <div class="scroll-container">
+    <div class="scroll-content">
+      <p>Scroll down — the footer navigation stays at the bottom.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+      <p>Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+      <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco.</p>
+      <p>Duis aute irure dolor in reprehenderit in voluptate velit.</p>
+      <p>Excepteur sint occaecat cupidatat non proident.</p>
+    </div>
+
+    <Header @position="bottom">
+      <:left>
+        <span>Footer Navigation</span>
+      </:left>
+      <:right>
+        <a href="/about">About</a>
+        <a href="/contact">Contact</a>
+      </:right>
+    </Header>
+  </div>
+
+  <style>
+    @scope {
+      .scroll-container {
+        height: 12rem;
+        overflow-y: auto;
+        border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.1));
+        border-radius: 0.5rem;
+      }
+      .scroll-content {
+        padding: 1rem;
+      }
+      .scroll-content p {
+        margin: 1.5rem 0;
+        color: light-dark(#666, #aaa);
+      }
+    }
+  </style>
 </template>
 ```
 

--- a/public/docs/3-components/header.md
+++ b/public/docs/3-components/header.md
@@ -5,7 +5,7 @@ The `<Header />` component provides a navigation bar for your application that c
 This component is ideal for app navigation, offering a clean and flexible layout with left and right content areas.
 
 ```gjs live
-import { Header, Button } from "nvp.ui";
+import { Header } from "nvp.ui";
 
 <template>
   <Header>
@@ -13,9 +13,8 @@ import { Header, Button } from "nvp.ui";
       <a href="/">nvp.ui</a>
     </:left>
     <:right>
-      <Button @onClick={{() => alert('Clicked!')}}>
-        Action
-      </Button>
+      <a href="/about">About</a>
+      <a href="/contact">Contact</a>
     </:right>
   </Header>
 </template>

--- a/public/docs/3-components/header.md
+++ b/public/docs/3-components/header.md
@@ -1,0 +1,82 @@
+# Header
+
+The `<Header />` component provides a navigation bar for your application that can be positioned at either the top or bottom of the screen.
+
+This component is ideal for app navigation, offering a clean and flexible layout with left and right content areas.
+
+```gjs live
+import { Header, Button } from "nvp.ui";
+
+<template>
+  <Header>
+    <:left>
+      <a href="/">nvp.ui</a>
+    </:left>
+    <:right>
+      <Button @onClick={{() => alert('Clicked!')}}>
+        Action
+      </Button>
+    </:right>
+  </Header>
+</template>
+```
+
+## Bottom Positioning
+
+The header can also be positioned at the bottom of the screen by setting `@position="bottom"`:
+
+```gjs live
+import { Header } from "nvp.ui";
+
+<template>
+  <Header @position="bottom">
+    <:left>
+      <span>Footer Navigation</span>
+    </:left>
+    <:right>
+      <a href="/about">About</a>
+      <a href="/contact">Contact</a>
+    </:right>
+  </Header>
+</template>
+```
+
+## Installation
+
+```bash
+pnpm add nvp.ui
+```
+
+## API Reference
+
+```gjs live no-shadow
+import { ComponentSignature } from "kolay";
+
+<template>
+  <ComponentSignature
+    @package="."
+    @module="declarations/components/header.gts"
+    @name="Signature"
+  />
+</template>
+```
+
+### State Attributes
+
+| key | description |
+| :---: | :--- |
+| `data-position` | Set to "top" or "bottom" based on the `@position` argument |
+
+### Styling
+
+Public selectors:
+
+| key | description |
+| :---: | :--- |
+| `.preem__header` | The header element |
+| `.preem__header__left` | Container for left-aligned content |
+| `.preem__header__right` | Container for right-aligned content |
+
+The header uses `position: sticky` by default with:
+- `top: 0` for default or `@position="top"`
+- `bottom: 0` for `@position="bottom"`

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -7,8 +7,16 @@
   padding: 1rem;
   background: var(--header-background);
   position: sticky;
-  top: 0;
   z-index: var(--z-site-nav);
+
+  /* Default to top positioning */
+  top: 0;
+
+  /* Bottom positioning when specified */
+  &[data-position="bottom"] {
+    top: auto;
+    bottom: 0;
+  }
 
   .preem__header__left {
   }

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -12,6 +12,12 @@
   /* Default to top positioning */
   top: 0;
 
+  /* Explicit top positioning */
+  &[data-position="top"] {
+    top: 0;
+    bottom: auto;
+  }
+
   /* Bottom positioning when specified */
   &[data-position="bottom"] {
     top: auto;

--- a/src/components/header.gts
+++ b/src/components/header.gts
@@ -4,13 +4,21 @@ import type { TOC } from "@ember/component/template-only";
 
 export interface Signature {
   Element: HTMLElement;
+  Args: {
+    /**
+     * Position of the header bar.
+     * Can be "top" (default) or "bottom".
+     */
+    position?: "top" | "bottom";
+  };
   Blocks: {
-    default: [];
+    left: [];
+    right: [];
   };
 }
 
 export const Header: TOC<Signature> = <template>
-  <header class="preem__header" ...attributes>
+  <header class="preem__header" data-position={{@position}} ...attributes>
     <span class="preem__header__left">
       {{yield to="left"}}
     </span>

--- a/tests/components/header-test.gts
+++ b/tests/components/header-test.gts
@@ -1,0 +1,88 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+
+import { Header } from "#src/index.ts";
+
+module("Header", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("it works with default (top) positioning", async function (assert) {
+    await render(
+      <template>
+        <Header>
+          <:left>
+            <span data-test-left>Left Content</span>
+          </:left>
+          <:right>
+            <span data-test-right>Right Content</span>
+          </:right>
+        </Header>
+      </template>,
+    );
+
+    assert.dom("header").exists();
+    assert.dom("header").hasClass("preem__header");
+    assert.dom("[data-test-left]").hasText("Left Content");
+    assert.dom("[data-test-right]").hasText("Right Content");
+    assert.dom("header").doesNotHaveAttribute("data-position");
+  });
+
+  test("it works with top positioning", async function (assert) {
+    await render(
+      <template>
+        <Header @position="top">
+          <:left>
+            <span>Left</span>
+          </:left>
+          <:right>
+            <span>Right</span>
+          </:right>
+        </Header>
+      </template>,
+    );
+
+    assert.dom("header").exists();
+    assert.dom("header").hasAttribute("data-position", "top");
+  });
+
+  test("it works with bottom positioning", async function (assert) {
+    await render(
+      <template>
+        <Header @position="bottom">
+          <:left>
+            <span data-test-left>Footer Left</span>
+          </:left>
+          <:right>
+            <span data-test-right>Footer Right</span>
+          </:right>
+        </Header>
+      </template>,
+    );
+
+    assert.dom("header").exists();
+    assert.dom("header").hasAttribute("data-position", "bottom");
+    assert.dom("[data-test-left]").hasText("Footer Left");
+    assert.dom("[data-test-right]").hasText("Footer Right");
+  });
+
+  test("left and right content are properly separated", async function (assert) {
+    await render(
+      <template>
+        <Header>
+          <:left>
+            <a href="/">Home</a>
+          </:left>
+          <:right>
+            <button type="button">Action</button>
+          </:right>
+        </Header>
+      </template>,
+    );
+
+    assert.dom(".preem__header__left").exists();
+    assert.dom(".preem__header__right").exists();
+    assert.dom(".preem__header__left a").hasText("Home");
+    assert.dom(".preem__header__right button").hasText("Action");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `@position` arg (`"top"` | `"bottom"`) to the Header component for sticky positioning
- Defaults to top when omitted
- CSS uses `data-position` attribute with `position: sticky`

Based on Copilot's work in #66 with the following fixes:
- Fixed `Blocks` signature from `default: []` to `left: []; right: []` matching the template's named blocks
- Renamed docs from `header.md` to `header.gjs.md` matching repo convention
- Fixed ComponentSignature `@module` path (removed `.gts` extension)
- Rebased onto current main

## Test plan
- [ ] Verify header sticks to top by default
- [ ] Verify `@position="bottom"` sticks to bottom
- [ ] Verify named blocks (left/right) render correctly

Fixes #65
Supersedes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)