### PR TITLE
Rename preem__ CSS prefix to nvp__

### DIFF
--- a/public/docs/3-components/external-link.gjs.md
+++ b/public/docs/3-components/external-link.gjs.md
@@ -44,7 +44,7 @@ none
 
 Public selectors:
 
-|                  key                  | description                                  |
-| :-----------------------------------: | :------------------------------------------- |
-|        `.preem__external-link`        | The anchor class                             |
-| `.preem__external-link__link-content` | The wrapper element around the block content |
+|                 key                 | description                                  |
+| :---------------------------------: | :------------------------------------------- |
+|        `.nvp__external-link`        | The anchor class                             |
+| `.nvp__external-link__link-content` | The wrapper element around the block content |

--- a/public/docs/3-components/header.gjs.md
+++ b/public/docs/3-components/header.gjs.md
@@ -124,11 +124,11 @@ import { ComponentSignature } from "kolay";
 
 Public selectors:
 
-|           key           | description                         |
-| :---------------------: | :---------------------------------- |
-|    `.preem__header`     | The header element                  |
-| `.preem__header__left`  | Container for left-aligned content  |
-| `.preem__header__right` | Container for right-aligned content |
+|          key          | description                         |
+| :-------------------: | :---------------------------------- |
+|    `.nvp__header`     | The header element                  |
+| `.nvp__header__left`  | Container for left-aligned content  |
+| `.nvp__header__right` | Container for right-aligned content |
 
 The header uses `position: sticky` by default with:
 

--- a/public/docs/3-components/theme-toggle.gjs.md
+++ b/public/docs/3-components/theme-toggle.gjs.md
@@ -82,9 +82,9 @@ none
 
 Public selectors:
 
-|             key             | description                                  |
-| :-------------------------: | :------------------------------------------- |
-| `.preem__site-theme-toggle` | Wrapper element around the underlying switch |
+|            key            | description                                  |
+| :-----------------------: | :------------------------------------------- |
+| `.nvp__site-theme-toggle` | Wrapper element around the underlying switch |
 
 ## Accessibility
 

--- a/src/components/button.css
+++ b/src/components/button.css
@@ -1,4 +1,4 @@
-.preem__button,
+.nvp__button,
 .nvp__tabs__tab {
   --button-background-color: var(--button-color);
   --button-hover-mix: 0%;
@@ -83,7 +83,7 @@
     --button-hover-mix: 30%;
     --button-hover-color-mix: #000;
     --button-interact-spread: -1px;
-    .preem__button__text {
+    .nvp__button__text {
       transform: scale(0.98);
     }
   }
@@ -98,7 +98,7 @@
   /* Control the tooltip from the button */
   &:hover,
   &:focus-visible {
-    .preem__button__disabled-reason {
+    .nvp__button__disabled-reason {
       opacity: 1;
       pointer-events: all;
     }
@@ -110,7 +110,7 @@
 *  the tab order, it can't be hidden (display: none)
 *  or (visibility: hidden)
 */
-.preem__button__disabled-reason {
+.nvp__button__disabled-reason {
   display: block;
   opacity: 0;
   pointer-events: none;

--- a/src/components/button.gts
+++ b/src/components/button.gts
@@ -78,7 +78,7 @@ const isString = (x: unknown) => typeof x === "string";
 export const Button: TOC<Signature> = <template>
   <Popover @inline={{true}} as |popover|>
     <button
-      class="preem__button"
+      class="nvp__button"
       data-variant={{@variant}}
       aria-disabled={{Boolean @disabled}}
       type="button"
@@ -89,7 +89,7 @@ export const Button: TOC<Signature> = <template>
       {{/if}}
 
       {{#if (or (has-block) (has-block "text"))}}
-        <span class="preem__button__text">{{yield}}{{yield to="text"}}</span>
+        <span class="nvp__button__text">{{yield}}{{yield to="text"}}</span>
       {{/if}}
 
       {{#if (or (has-block "end") @end)}}
@@ -105,7 +105,7 @@ export const Button: TOC<Signature> = <template>
       {{#if @disabled}}
         {{! Needs more work -- maybe using a menu instead of popover }}
         {{! template-lint-disable no-nested-interactive }}
-        <popover.Content tabindex="0" class="preem__button__disabled-reason">
+        <popover.Content tabindex="0" class="nvp__button__disabled-reason">
           {{#if (isString @disabled)}}
             {{@disabled}}
           {{else}}

--- a/src/components/external-link.css
+++ b/src/components/external-link.css
@@ -1,4 +1,4 @@
-.preem__external-link {
+.nvp__external-link {
   display: inline-grid;
   grid-auto-flow: column;
   align-items: baseline;

--- a/src/components/external-link.gts
+++ b/src/components/external-link.gts
@@ -14,8 +14,8 @@ export interface Signature {
 }
 
 export const ExternalLink: TOC<Signature> = <template>
-  <PrimitiveExternalLink class="preem__external-link" ...attributes>
-    <span class="preem__external-link__link-content">{{yield}}</span>
+  <PrimitiveExternalLink class="nvp__external-link" ...attributes>
+    <span class="nvp__external-link__link-content">{{yield}}</span>
     <Arrow />
   </PrimitiveExternalLink>
 </template>;

--- a/src/components/focus.css
+++ b/src/components/focus.css
@@ -25,7 +25,7 @@ textarea,
   }
 }
 
-.preem__site-theme-toggle {
+.nvp__site-theme-toggle {
   &:has(:focus),
   &:has(:focus-visible) {
     label {

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -1,4 +1,4 @@
-.preem__header {
+.nvp__header {
   display: flex;
   align-items: center;
   gap: 1rem;
@@ -23,12 +23,12 @@
     bottom: 0;
   }
 
-  .preem__header__left {
+  .nvp__header__left {
     display: flex;
     align-items: center;
     gap: 0.75rem;
   }
-  .preem__header__right {
+  .nvp__header__right {
     display: flex;
     align-items: center;
     gap: 1rem;

--- a/src/components/header.gts
+++ b/src/components/header.gts
@@ -18,11 +18,11 @@ export interface Signature {
 }
 
 export const Header: TOC<Signature> = <template>
-  <header class="preem__header surface elevation-xl2" data-position={{@position}} ...attributes>
-    <span class="preem__header__left">
+  <header class="nvp__header surface elevation-xl2" data-position={{@position}} ...attributes>
+    <span class="nvp__header__left">
       {{yield to="left"}}
     </span>
-    <span class="preem__header__right">
+    <span class="nvp__header__right">
       {{yield to="right"}}
     </span>
   </header>

--- a/src/components/progress-circle.gts
+++ b/src/components/progress-circle.gts
@@ -17,8 +17,8 @@ export interface Signature {
 }
 
 export const ProgressCircle: TOC<Signature> = <template>
-  <Progress class="preem_progress-circle" @value={{@value}} ...attributes as |x|>
-    <x.Indicator class="preem_progress" />
+  <Progress class="nvp_progress-circle" @value={{@value}} ...attributes as |x|>
+    <x.Indicator class="nvp_progress" />
     <svg width="200" height="200" viewPort="0 0 100 100">
       <circle
         r={{r}}
@@ -42,8 +42,8 @@ export const ProgressCircle: TOC<Signature> = <template>
     </svg>
     {{! template-lint-disable no-forbidden-elements }}
     <style>
-      .preem_progress-circle {
-        .preem_progress {
+      .nvp_progress-circle {
+        .nvp_progress {
           height: 200px;
           width: 200px;
           position: absolute;
@@ -56,7 +56,7 @@ export const ProgressCircle: TOC<Signature> = <template>
           stroke-width: 1rem;
         }
 
-        .preem_progress:after {
+        .nvp_progress:after {
           content: attr(data-percent) "%";
           line-height: 200px;
           font-size: 1.5rem;

--- a/src/components/theme-toggle.css
+++ b/src/components/theme-toggle.css
@@ -1,4 +1,4 @@
-.preem__site-theme-toggle {
+.nvp__site-theme-toggle {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -7,7 +7,7 @@
   margin: 0;
   transition: background 0.2s linear;
 
-  .preem__sr-only {
+  .nvp__sr-only {
     margin-left: -0.5rem;
   }
   input[type="checkbox"][role="switch"] {
@@ -59,7 +59,7 @@
     transform: translateX(120%);
   }
 }
-.preem__sr-only {
+.nvp__sr-only {
   width: 0px;
   max-width: 0px;
   height: 0px;

--- a/src/components/theme-toggle.gts
+++ b/src/components/theme-toggle.gts
@@ -29,17 +29,17 @@ export interface Signature {
 }
 
 export const ThemeToggle: TOC<Signature> = <template>
-  <Switch class="preem__site-theme-toggle" ...attributes as |s|>
+  <Switch class="nvp__site-theme-toggle" ...attributes as |s|>
     <s.Control name="color-scheme" checked={{(isDark)}} {{on "change" toggleTheme}} />
     <s.Label>
-      <span class="preem__sr-only">Toggle between light and dark mode</span>
+      <span class="nvp__sr-only">Toggle between light and dark mode</span>
       {{!
         🎵 It's raining, it's pouring, ... 🎵
         https://www.youtube.com/watch?v=ll5ykbAumD4
       }}
       <Moon />
       <Sun />
-      <span class="ball preem__button"></span>
+      <span class="ball nvp__button"></span>
     </s.Label>
   </Switch>
 </template>;

--- a/src/test-support/theme-toggle.ts
+++ b/src/test-support/theme-toggle.ts
@@ -2,7 +2,7 @@ import { assert } from "@ember/debug";
 import { click, find } from "@ember/test-helpers";
 
 const selectors = {
-  root: "preem__site-theme-toggle",
+  root: "nvp__site-theme-toggle",
   checkbox: '[name="color-scheme"]',
 };
 

--- a/tests/components/header-test.gts
+++ b/tests/components/header-test.gts
@@ -22,7 +22,7 @@ module("Header", function (hooks) {
     );
 
     assert.dom("header").exists();
-    assert.dom("header").hasClass("preem__header");
+    assert.dom("header").hasClass("nvp__header");
     assert.dom("[data-test-left]").hasText("Left Content");
     assert.dom("[data-test-right]").hasText("Right Content");
     assert.dom("header").doesNotHaveAttribute("data-position");
@@ -80,9 +80,9 @@ module("Header", function (hooks) {
       </template>,
     );
 
-    assert.dom(".preem__header__left").exists();
-    assert.dom(".preem__header__right").exists();
-    assert.dom(".preem__header__left a").hasText("Home");
-    assert.dom(".preem__header__right button").hasText("Action");
+    assert.dom(".nvp__header__left").exists();
+    assert.dom(".nvp__header__right").exists();
+    assert.dom(".nvp__header__left a").hasText("Home");
+    assert.dom(".nvp__header__right button").hasText("Action");
   });
 });


### PR DESCRIPTION
## Summary
Bulk rename of all `preem__` / `preem_` CSS class prefixes to `nvp__` / `nvp_` across the entire codebase.

**15 files changed**, purely mechanical find-and-replace with no logic changes.

### Components affected
- Button (`preem__button` → `nvp__button`)
- Header (`preem__header` → `nvp__header`)
- ExternalLink (`preem__external-link` → `nvp__external-link`)
- ThemeToggle (`preem__site-theme-toggle` → `nvp__site-theme-toggle`)
- ProgressCircle (`preem_progress-circle` → `nvp_progress-circle`)
- Focus styles, sr-only utility, test-support selectors

### Also updated
- Docs (header, external-link, theme-toggle pages)
- Tests (header-test.gts)

## Test plan
- [ ] All existing tests pass (pure rename, no behavior change)
- [ ] Visual inspection — no style changes, just class names

🤖 Generated with [Claude Code](https://claude.com/claude-code)