### PR TITLE
Match Limber's kbd hint style in Menu

### DIFF
--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -63,13 +63,12 @@
 }
 
 .nvp__menu__content {
-  position: relative;
+  anchor-name: --nvp-menu;
   min-width: 10rem;
   border-radius: var(--radius);
   border: var(--border-width) var(--border-style) var(--border-color);
   padding: 0;
   z-index: var(--z-hover);
-  overflow: visible;
   background: var(--color-page-background);
 }
 
@@ -103,12 +102,13 @@
 }
 
 .nvp__menu__kbd-hints {
-  position: absolute;
-  bottom: 0;
-  right: 0.25rem;
-  transform: translateY(100%);
+  position: fixed;
+  position-anchor: --nvp-menu;
+  top: anchor(bottom);
+  left: anchor(right);
+  translate: calc(-100% - 0.25rem) 0;
   width: max-content;
-  z-index: -1;
+  z-index: calc(var(--z-hover) - 1);
   border-radius: 0 0 var(--radius) var(--radius);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
   padding: 0.15rem 0.5rem 0.25rem 0.5rem;

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -108,14 +108,12 @@
   transform: translateY(100%);
   width: max-content;
   z-index: -1;
-  background: var(--surface-background-color, var(--color-page-background));
+  background: color-mix(in oklab, var(--color-page-background) 85%, var(--color-text));
   border-radius: 0 0 var(--radius) var(--radius);
-  padding: 0.1rem 0.6rem 0.3rem 1rem;
+  padding: 0.15rem 0.6rem 0.3rem 0.6rem;
   font-size: 0.65rem;
-  color: color-mix(in oklab, var(--color-text) 50%, transparent);
+  color: color-mix(in oklab, var(--color-text) 45%, transparent);
   pointer-events: none;
-  display: flex;
-  gap: var(--gap-3);
 
   .ember-primitives__key {
     text-transform: uppercase;

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -104,8 +104,9 @@
 .nvp__menu__kbd-hints {
   position: absolute;
   bottom: 0;
-  left: 0;
+  right: 0;
   transform: translateY(100%);
+  width: max-content;
   z-index: -1;
   background: var(--surface-background-color, var(--color-page-background));
   border-radius: 0 0 var(--radius) var(--radius);

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -101,28 +101,24 @@
 }
 
 .nvp__menu__kbd-hints {
-  display: flex;
-  gap: var(--gap-3);
-  justify-content: center;
-  padding: var(--padding-1) var(--padding-2);
-  border-top: var(--border-width) var(--border-style) var(--border-color);
-  font-size: 0.7rem;
+  padding: 0.1rem 0.6rem 0.3rem 1rem;
+  font-size: 0.65rem;
   color: color-mix(in oklab, var(--color-text) 50%, transparent);
 
   .ember-primitives__key {
     text-transform: uppercase;
-    background-color: color-mix(in oklab, var(--color-text) 10%, transparent);
+    background-color: #eee;
     border-radius: 2px;
-    border: 1px solid color-mix(in oklab, var(--color-text) 20%, transparent);
+    border: 1px solid #b4b4b4;
     box-shadow:
-      0 1px 1px rgba(0, 0, 0, 0.1),
-      0 2px 0 0 rgba(255, 255, 255, 0.1) inset;
-    color: color-mix(in oklab, var(--color-text) 70%, transparent);
+      0 1px 1px rgba(0, 0, 0, 0.2),
+      0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
+    color: #333;
     display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 600;
+    font-size: 0.65rem;
+    font-weight: 700;
     line-height: 1;
-    padding: 1px 4px;
+    padding: 2px 4px;
     white-space: nowrap;
   }
 }

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -70,6 +70,7 @@
   padding: var(--padding-1) 0;
   z-index: var(--z-hover);
   overflow: visible;
+  background: var(--color-page-background);
 }
 
 .nvp__menu__item,
@@ -113,7 +114,7 @@
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
   padding: 0.15rem 0.5rem 0.25rem 0.5rem;
   font-size: 0.6rem;
-  color: color-mix(in oklab, var(--color-text) 45%, transparent);
+  color: color-mix(in oklab, var(--color-text) 60%, transparent);
   pointer-events: none;
 
   .ember-primitives__key {

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -63,12 +63,13 @@
 }
 
 .nvp__menu__content {
+  position: relative;
   min-width: 10rem;
   border-radius: var(--radius);
   border: var(--border-width) var(--border-style) var(--border-color);
   padding: var(--padding-1) 0;
   z-index: var(--z-hover);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .nvp__menu__item,
@@ -101,9 +102,19 @@
 }
 
 .nvp__menu__kbd-hints {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  transform: translateY(100%);
+  z-index: -1;
+  background: var(--surface-background-color, var(--color-page-background));
+  border-radius: 0 0 var(--radius) var(--radius);
   padding: 0.1rem 0.6rem 0.3rem 1rem;
   font-size: 0.65rem;
   color: color-mix(in oklab, var(--color-text) 50%, transparent);
+  pointer-events: none;
+  display: flex;
+  gap: var(--gap-3);
 
   .ember-primitives__key {
     text-transform: uppercase;

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -67,7 +67,7 @@
   min-width: 10rem;
   border-radius: var(--radius);
   border: var(--border-width) var(--border-style) var(--border-color);
-  padding: var(--padding-1) 0;
+  padding: 0;
   z-index: var(--z-hover);
   overflow: visible;
   background: var(--color-page-background);

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -104,14 +104,15 @@
 .nvp__menu__kbd-hints {
   position: absolute;
   bottom: 0;
-  right: 0;
+  right: 0.25rem;
   transform: translateY(100%);
   width: max-content;
   z-index: -1;
   background: color-mix(in oklab, var(--color-page-background) 85%, var(--color-text));
   border-radius: 0 0 var(--radius) var(--radius);
-  padding: 0.15rem 0.6rem 0.3rem 0.6rem;
-  font-size: 0.65rem;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
+  padding: 0.15rem 0.5rem 0.25rem 0.5rem;
+  font-size: 0.6rem;
   color: color-mix(in oklab, var(--color-text) 45%, transparent);
   pointer-events: none;
 
@@ -125,10 +126,10 @@
       0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
     color: #333;
     display: inline-block;
-    font-size: 0.65rem;
+    font-size: 0.55rem;
     font-weight: 700;
     line-height: 1;
-    padding: 2px 4px;
+    padding: 1px 3px;
     white-space: nowrap;
   }
 }

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -109,7 +109,6 @@
   transform: translateY(100%);
   width: max-content;
   z-index: -1;
-  background: color-mix(in oklab, var(--color-page-background) 85%, var(--color-text));
   border-radius: 0 0 var(--radius) var(--radius);
   box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
   padding: 0.15rem 0.5rem 0.25rem 0.5rem;

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -80,7 +80,7 @@ const StyledContent = <template>
         Separator=(component StyledSeparator Separator=items.Separator)
       )
     }}
-    <div class="nvp__menu__kbd-hints surface">
+    <div class="nvp__menu__kbd-hints surface elevation-lg">
       press
       <Key>esc</Key>
       to close

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -81,9 +81,9 @@ const StyledContent = <template>
       )
     }}
     <div class="nvp__menu__kbd-hints">
-      press
-      <Key>esc</Key>
-      to close
+      <span><Key>↑</Key> <Key>↓</Key> navigate</span>
+      <span><Key>enter</Key> select</span>
+      <span><Key>esc</Key> close</span>
     </div>
   </@Content>
 </template>;

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -80,7 +80,7 @@ const StyledContent = <template>
         Separator=(component StyledSeparator Separator=items.Separator)
       )
     }}
-    <div class="nvp__menu__kbd-hints">
+    <div class="nvp__menu__kbd-hints surface">
       press
       <Key>esc</Key>
       to close

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -81,9 +81,9 @@ const StyledContent = <template>
       )
     }}
     <div class="nvp__menu__kbd-hints">
-      <span><Key>↑</Key> <Key>↓</Key> navigate</span>
-      <span><Key>enter</Key> select</span>
-      <span><Key>esc</Key> close</span>
+      press
+      <Key>esc</Key>
+      to close
     </div>
   </@Content>
 </template>;

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -82,7 +82,6 @@ const StyledContent = <template>
     }}
     <div class="nvp__menu__kbd-hints">
       <span><Key>↑</Key> <Key>↓</Key> navigate</span>
-      <span><Key>enter</Key> select</span>
       <span><Key>esc</Key> close</span>
     </div>
   </@Content>

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -59,7 +59,7 @@ export const Menu: TOC<Signature> = <template>
     {{yield
       (hash
         Trigger=(component StyledTrigger Trigger=menu.Trigger variant=@variant)
-        Content=(component StyledContent Content=menu.Content)
+        Content=(component StyledContent Content=menu.Content isOpen=menu.isOpen)
       )
     }}
   </PrimitiveMenu>
@@ -80,12 +80,14 @@ const StyledContent = <template>
         Separator=(component StyledSeparator Separator=items.Separator)
       )
     }}
+  </@Content>
+  {{#if @isOpen}}
     <div class="nvp__menu__kbd-hints surface elevation-lg">
       press
       <Key>esc</Key>
       to close
     </div>
-  </@Content>
+  {{/if}}
 </template>;
 
 const StyledItem = <template>

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -81,8 +81,9 @@ const StyledContent = <template>
       )
     }}
     <div class="nvp__menu__kbd-hints">
-      <span><Key>↑</Key> <Key>↓</Key> navigate</span>
-      <span><Key>esc</Key> close</span>
+      press
+      <Key>esc</Key>
+      to close
     </div>
   </@Content>
 </template>;

--- a/tests/components/menu-test.gts
+++ b/tests/components/menu-test.gts
@@ -63,7 +63,7 @@ module("Menu", function (hooks) {
     await click(".nvp__menu__trigger");
 
     assert.dom(".nvp__menu__kbd-hints").exists();
-    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 3 });
+    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 1 });
   });
 
   test("renders items, link items, and separators", async function (assert) {

--- a/tests/components/menu-test.gts
+++ b/tests/components/menu-test.gts
@@ -63,7 +63,7 @@ module("Menu", function (hooks) {
     await click(".nvp__menu__trigger");
 
     assert.dom(".nvp__menu__kbd-hints").exists();
-    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 1 });
+    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 4 });
   });
 
   test("renders items, link items, and separators", async function (assert) {

--- a/tests/components/menu-test.gts
+++ b/tests/components/menu-test.gts
@@ -63,7 +63,7 @@ module("Menu", function (hooks) {
     await click(".nvp__menu__trigger");
 
     assert.dom(".nvp__menu__kbd-hints").exists();
-    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 4 });
+    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 1 });
   });
 
   test("renders items, link items, and separators", async function (assert) {

--- a/tests/components/menu-test.gts
+++ b/tests/components/menu-test.gts
@@ -63,7 +63,7 @@ module("Menu", function (hooks) {
     await click(".nvp__menu__trigger");
 
     assert.dom(".nvp__menu__kbd-hints").exists();
-    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 4 });
+    assert.dom(".nvp__menu__kbd-hints kbd").exists({ count: 3 });
   });
 
   test("renders items, link items, and separators", async function (assert) {


### PR DESCRIPTION
## Summary

- Simplified menu kbd hint from multi-shortcut display to Limber's `press ESC to close` pattern
- Updated `<kbd>` styling to match Limber/MDN keycap look: `#eee` background, `#b4b4b4` border, inset box-shadow for 3D raised effect, uppercase, `font-weight: 700`
- Inspected Limber's live styles via Chrome DevTools to match exactly

## Test plan

- [x] All 80 tests pass
- [x] All lints pass
- [x] Visually verified menu matches Limber's kbd hint pattern


🤖 Generated with [Claude Code](https://claude.com/claude-code)