### PR TITLE
Wire up Button's @onClick argument

### DIFF
--- a/src/components/button.gts
+++ b/src/components/button.gts
@@ -2,6 +2,9 @@ import "./variables.css";
 import "./focus.css";
 import "./button.css";
 
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+
 import { Popover } from "ember-primitives/components/popover";
 
 import type { TOC } from "@ember/component/template-only";
@@ -23,12 +26,12 @@ export interface Signature {
      *
      * Sets the `aria-disabled` attribute as well.
      */
-    disabled: string | ComponentLike;
+    disabled?: string | ComponentLike;
 
     /**
      * What action to perform upon click
      */
-    onClick: (event: Event) => void;
+    onClick?: (event: Event) => void;
 
     /**
      * What colors to make the button.
@@ -75,6 +78,16 @@ export interface Signature {
 const or = (a: unknown, b: unknown) => a || b;
 const isString = (x: unknown) => typeof x === "string";
 
+function handleClick(
+  disabled: Signature["Args"]["disabled"],
+  onClick: Signature["Args"]["onClick"],
+  event: Event,
+) {
+  if (disabled) return;
+
+  onClick?.(event);
+}
+
 export const Button: TOC<Signature> = <template>
   <Popover @inline={{true}} as |popover|>
     <button
@@ -83,6 +96,7 @@ export const Button: TOC<Signature> = <template>
       aria-disabled={{Boolean @disabled}}
       type="button"
       {{popover.reference}}
+      {{on "click" (fn handleClick @disabled @onClick)}}
     >
       {{#if (or (has-block "start") @start)}}
         <span>{{@start}}{{yield to="start"}}</span>

--- a/tests/components/button-test.gts
+++ b/tests/components/button-test.gts
@@ -1,0 +1,55 @@
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+
+import { Button } from "#src/index.ts";
+
+module("Button", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("calls @onClick when clicked", async function (assert) {
+    const handleClick = () => assert.step("clicked");
+
+    await render(
+      <template>
+        <Button @onClick={{handleClick}}>Click me</Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasText("Click me");
+
+    await click(".nvp__button");
+
+    assert.verifySteps(["clicked"]);
+  });
+
+  test("does not call @onClick when disabled", async function (assert) {
+    const handleClick = () => assert.step("clicked");
+
+    await render(
+      <template>
+        <Button @disabled="Reason for being disabled" @onClick={{handleClick}}>
+          Click me
+        </Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-disabled");
+
+    await click(".nvp__button");
+
+    assert.verifySteps([]);
+  });
+
+  test("can be clicked without an @onClick", async function (assert) {
+    await render(
+      <template>
+        <Button>Click me</Button>
+      </template>,
+    );
+
+    await click(".nvp__button");
+
+    assert.dom(".nvp__button").hasText("Click me");
+  });
+});


### PR DESCRIPTION
## The bug

`Button`'s `Signature` declares an `onClick` arg:

```ts
/**
 * What action to perform upon click
 */
onClick: (event: Event) => void;
```

…but the template never binds it — there is no `{{on "click" @onClick}}` anywhere — so `<Button @onClick={{...}}>` type-checks fine and then silently does nothing at runtime.

Found while building [NullVoxPopuli/midiplayer](https://github.com/NullVoxPopuli/midiplayer) (porting ryohey/signal): the toolbar buttons rendered but never responded to clicks.

## The fix

- Bind `{{on "click" (fn handleClick @disabled @onClick)}}` on the `<button>`. The handler is guarded: it does nothing when `@disabled` is set (matching the `aria-disabled` semantics — the disabled-reason popover behavior is untouched), and `@onClick` is invoked optionally.
- Mark `@disabled` and `@onClick` as optional in the `Signature`. The template already treats `@disabled` as optional (`{{#if @disabled}}`), and a disabled-only button shouldn't be forced to pass a click handler (nor vice versa).
- Add `tests/components/button-test.gts` covering: `@onClick` fires on click, does not fire when `@disabled` is set, and clicking without `@onClick` doesn't error.

`pnpm lint` and `pnpm test` pass (83/83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)