### PR TITLE
Add ToggleButton (composed from Button via new splattributes)

### DIFF
--- a/public/docs/3-components/toggle-button.gjs.md
+++ b/public/docs/3-components/toggle-button.gjs.md
@@ -1,0 +1,70 @@
+# ToggleButton
+
+A toggle button is a button with persistent on / off state (mute, loop, record-arm, etc).
+It composes the [Button](/Docs/3-components/button) component, so disabled toggles
+still explain _why_ they are disabled, and adds the `aria-pressed` attribute --
+which is what tells assistive technology that the button is a toggle, and whether
+that toggle is currently on.
+
+```gjs live no-shadow
+import { ToggleButton } from "nvp.ui";
+import { PortalTargets } from "ember-primitives";
+import { cell } from "ember-resources";
+
+const muted = cell(false);
+const toggleMuted = () => (muted.current = !muted.current);
+
+<template>
+  <PortalTargets />
+
+  <ToggleButton @pressed={{muted.current}} @onClick={{toggleMuted}}>
+    {{if muted.current "Muted 🔇" "Mute 🔊"}}
+  </ToggleButton>
+
+  <br /><br />
+  <ToggleButton @pressed={{true}} @variant="primary">Primary</ToggleButton>
+  <ToggleButton @pressed={{true}} @variant="secondary">Secondary</ToggleButton>
+  <ToggleButton @pressed={{true}} @variant="danger">Danger</ToggleButton>
+
+  <br /><br />
+  <ToggleButton @pressed={{true}} @disabled="The audio engine has not started yet">
+    Record
+  </ToggleButton>
+</template>
+```
+
+## Installation
+
+```bash
+pnpm add nvp.ui
+```
+
+## Accessibility
+
+- screen-reader users hear the toggle state, e.g. "Mute, toggle button, pressed", per the [WAI-ARIA button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/)
+- everything from [Button](/Docs/3-components/button) applies: the toggle is always focusable, and the disabled reason is a focusable tooltip
+
+## API Reference
+
+```gjs live no-shadow
+import { ComponentSignature } from "kolay";
+
+<template>
+  <ComponentSignature
+    @package="."
+    @module="declarations/components/toggle-button"
+    @name="Signature"
+  />
+</template>
+```
+
+### State Attributes
+
+|       key        | description                                 |
+| :--------------: | :------------------------------------------ |
+| `[aria-pressed]` | `"true"` or `"false"`, mirroring `@pressed` |
+
+### Styling
+
+Pressed toggles (`[aria-pressed="true"]`) render with the same held-down look as
+an `:active` button.

--- a/src/components/button.css
+++ b/src/components/button.css
@@ -88,6 +88,13 @@
     }
   }
 
+  /* Toggle buttons (aria-pressed via ...attributes) look held-down while pressed */
+  &[aria-pressed="true"] {
+    --button-hover-mix: 30%;
+    --button-hover-color-mix: #000;
+    --button-interact-spread: -1px;
+  }
+
   &[aria-disabled] {
     --button-disable-mix: 50%;
     --button-interact-spread: -1px;

--- a/src/components/button.gts
+++ b/src/components/button.gts
@@ -14,16 +14,9 @@ export interface Signature {
   /**
    * The underlying `<button>` element.
    *
-   * Attributes and modifiers are forwarded via `...attributes`, so
-   * toggle-button state (`aria-pressed`), extra event listeners
-   * (`{{on "mousedown" ...}}`), test selectors, etc. may be applied
-   * directly:
-   *
-   * ```gjs
-   * <Button aria-pressed="{{if this.muted 'true' 'false'}}" @onClick={{this.toggleMute}}>
-   *   Mute
-   * </Button>
-   * ```
+   * Attributes and modifiers are forwarded via `...attributes`,
+   * enabling toggle-button state (`aria-pressed`), extra event
+   * listeners, test selectors, etc.
    */
   Element: HTMLButtonElement;
   Args: {

--- a/src/components/button.gts
+++ b/src/components/button.gts
@@ -12,10 +12,20 @@ import type { ComponentLike } from "@glint/template";
 
 export interface Signature {
   /**
-   * The underlying button element is not exposed,
-   * as doing so could lead to misuse.
+   * The underlying `<button>` element.
+   *
+   * Attributes and modifiers are forwarded via `...attributes`, so
+   * toggle-button state (`aria-pressed`), extra event listeners
+   * (`{{on "mousedown" ...}}`), test selectors, etc. may be applied
+   * directly:
+   *
+   * ```gjs
+   * <Button aria-pressed="{{if this.muted 'true' 'false'}}" @onClick={{this.toggleMute}}>
+   *   Mute
+   * </Button>
+   * ```
    */
-  Element: null;
+  Element: HTMLButtonElement;
   Args: {
     /**
      * The `@disabled` describes why a button is disabled.
@@ -95,6 +105,7 @@ export const Button: TOC<Signature> = <template>
       data-variant={{@variant}}
       aria-disabled={{Boolean @disabled}}
       type="button"
+      ...attributes
       {{popover.reference}}
       {{on "click" (fn handleClick @disabled @onClick)}}
     >

--- a/src/components/toggle-button.gts
+++ b/src/components/toggle-button.gts
@@ -1,0 +1,73 @@
+import { Button } from "./button.gts";
+
+import type { Signature as ButtonSignature } from "./button.gts";
+import type { TOC } from "@ember/component/template-only";
+
+export interface Signature {
+  /**
+   * The underlying `<button>` element, provided by `<Button>`.
+   */
+  Element: ButtonSignature["Element"];
+  Args: {
+    /**
+     * Whether the toggle is currently pressed (on).
+     *
+     * Rendered as the `aria-pressed` attribute, which is what identifies
+     * the button to assistive technology as a toggle button, and whether
+     * that toggle is currently on or off.
+     */
+    pressed: boolean;
+
+    /**
+     * The `@disabled` describes why the toggle is disabled.
+     * This information will appear in a focusable tooltip so that users may
+     * understand why their button is disabled.
+     *
+     * Additionally, when clicking the button, the `@disabled` information will appear.
+     *
+     * Sets the `aria-disabled` attribute as well.
+     */
+    disabled?: ButtonSignature["Args"]["disabled"];
+
+    /**
+     * What action to perform upon click, typically flipping the state
+     * passed to `@pressed`.
+     */
+    onClick?: ButtonSignature["Args"]["onClick"];
+
+    /**
+     * What colors to make the button.
+     */
+    variant?: ButtonSignature["Args"]["variant"];
+
+    /**
+     * Content before the button contents (such as for an icon)
+     */
+    start?: ButtonSignature["Args"]["start"];
+
+    /**
+     * Content after the button contents (such as for an icon)
+     */
+    end?: ButtonSignature["Args"]["end"];
+  };
+  Blocks: {
+    /**
+     * Default content for button contents
+     */
+    default: [];
+  };
+}
+
+export const ToggleButton: TOC<Signature> = <template>
+  <Button
+    aria-pressed={{if @pressed "true" "false"}}
+    ...attributes
+    @disabled={{@disabled}}
+    @onClick={{@onClick}}
+    @variant={{@variant}}
+    @start={{@start}}
+    @end={{@end}}
+  >
+    {{yield}}
+  </Button>
+</template>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export { politeSticky } from "./components/polite-sticky.gts";
 export { Shell } from "./components/shell.gts";
 export { ThemeToggle } from "./components/theme-toggle.gts";
 export { Timeline } from "./components/timeline.gts";
+export { ToggleButton } from "./components/toggle-button.gts";

--- a/tests/components/button-test.gts
+++ b/tests/components/button-test.gts
@@ -1,6 +1,9 @@
+import { on } from "@ember/modifier";
 import { click, render } from "@ember/test-helpers";
 import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
+
+import { TrackedObject } from "tracked-built-ins";
 
 import { Button } from "#src/index.ts";
 
@@ -51,5 +54,118 @@ module("Button", function (hooks) {
     await click(".nvp__button");
 
     assert.dom(".nvp__button").hasText("Click me");
+  });
+
+  test("splatted attributes land on the underlying button", async function (assert) {
+    await render(
+      <template>
+        <Button aria-pressed="true" data-test-mute>Mute</Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "true");
+    assert.dom(".nvp__button").hasAttribute("data-test-mute");
+  });
+
+  test("without splatted attributes, none are present", async function (assert) {
+    await render(
+      <template>
+        <Button>Click me</Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").doesNotHaveAttribute("aria-pressed");
+  });
+
+  test("splatted class merges with the component's own class", async function (assert) {
+    await render(
+      <template>
+        <Button class="custom-class">Click me</Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasClass("nvp__button");
+    assert.dom(".nvp__button").hasClass("custom-class");
+  });
+
+  test("splattributes compose with @onClick to form a toggle button", async function (assert) {
+    const state = new TrackedObject({ pressed: false });
+    const toggle = () => (state.pressed = !state.pressed);
+
+    await render(
+      <template>
+        <Button aria-pressed="{{if state.pressed 'true' 'false'}}" @onClick={{toggle}}>
+          Mute
+        </Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "false");
+
+    await click(".nvp__button");
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "true");
+
+    await click(".nvp__button");
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "false");
+  });
+
+  test("{{on 'click'}} via splattributes fires", async function (assert) {
+    const handleClick = () => assert.step("clicked");
+
+    await render(
+      <template>
+        <Button {{on "click" handleClick}}>Click me</Button>
+      </template>,
+    );
+
+    await click(".nvp__button");
+
+    assert.verifySteps(["clicked"]);
+  });
+
+  test("a disabled toggle still shows its reason and does not call @onClick", async function (assert) {
+    const handleClick = () => assert.step("clicked");
+
+    await render(
+      <template>
+        <Button aria-pressed="true" @disabled="Reason for being disabled" @onClick={{handleClick}}>
+          Mute
+        </Button>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "true");
+    assert.dom(".nvp__button").hasAttribute("aria-disabled");
+    assert.dom(".nvp__button__disabled-reason").hasText("Reason for being disabled");
+
+    await click(".nvp__button");
+
+    assert.verifySteps([]);
+  });
+
+  test("{{on 'click'}} via splattributes is NOT suppressed by @disabled", async function (assert) {
+    // Unlike @onClick, event listeners attached via splattributes bind
+    // directly to the element, so the component cannot intercept them.
+    // The button uses aria-disabled (not the disabled attribute) so that
+    // the "why disabled" popover stays focusable, which means the browser
+    // does not suppress these events either.
+    //
+    // This test documents that tradeoff: use @onClick when the action
+    // should be suppressed while disabled.
+    const handleClick = () => assert.step("clicked");
+
+    await render(
+      <template>
+        <Button @disabled="Reason for being disabled" {{on "click" handleClick}}>
+          Click me
+        </Button>
+      </template>,
+    );
+
+    await click(".nvp__button");
+
+    assert.verifySteps(["clicked"]);
   });
 });

--- a/tests/components/button-test.gts
+++ b/tests/components/button-test.gts
@@ -88,7 +88,7 @@ module("Button", function (hooks) {
     assert.dom(".nvp__button").hasClass("custom-class");
   });
 
-  test("splattributes compose with @onClick to form a toggle button", async function (assert) {
+  test("splatted attributes update reactively", async function (assert) {
     const state = new TrackedObject({ pressed: false });
     const toggle = () => (state.pressed = !state.pressed);
 

--- a/tests/components/toggle-button-test.gts
+++ b/tests/components/toggle-button-test.gts
@@ -1,0 +1,88 @@
+import { click, render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+
+import { TrackedObject } from "tracked-built-ins";
+
+import { ToggleButton } from "#src/index.ts";
+
+module("ToggleButton", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("@pressed={{true}} renders aria-pressed='true'", async function (assert) {
+    await render(
+      <template>
+        <ToggleButton @pressed={{true}}>Mute</ToggleButton>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasText("Mute");
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "true");
+  });
+
+  test("@pressed={{false}} renders aria-pressed='false'", async function (assert) {
+    await render(
+      <template>
+        <ToggleButton @pressed={{false}}>Mute</ToggleButton>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "false");
+  });
+
+  test("toggles via @onClick", async function (assert) {
+    const state = new TrackedObject({ pressed: false });
+    const toggle = () => (state.pressed = !state.pressed);
+
+    await render(
+      <template>
+        <ToggleButton @pressed={{state.pressed}} @onClick={{toggle}}>Mute</ToggleButton>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "false");
+
+    await click(".nvp__button");
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "true");
+
+    await click(".nvp__button");
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "false");
+  });
+
+  test("when disabled, still shows the reason and does not call @onClick", async function (assert) {
+    const handleClick = () => assert.step("clicked");
+
+    await render(
+      <template>
+        <ToggleButton
+          @pressed={{true}}
+          @disabled="Reason for being disabled"
+          @onClick={{handleClick}}
+        >
+          Mute
+        </ToggleButton>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("aria-pressed", "true");
+    assert.dom(".nvp__button").hasAttribute("aria-disabled");
+    assert.dom(".nvp__button__disabled-reason").hasText("Reason for being disabled");
+
+    await click(".nvp__button");
+
+    assert.verifySteps([]);
+  });
+
+  test("forwards @variant and splatted attributes to the underlying button", async function (assert) {
+    await render(
+      <template>
+        <ToggleButton @pressed={{false}} @variant="primary" data-test-mute>Mute</ToggleButton>
+      </template>,
+    );
+
+    assert.dom(".nvp__button").hasAttribute("data-variant", "primary");
+    assert.dom(".nvp__button").hasAttribute("data-test-mute");
+  });
+});


### PR DESCRIPTION
## Motivation

Toggle buttons (mute/solo, loop, metronome, record-arm, tool pickers — e.g. in [midiplayer](https://github.com/NullVoxPopuli/midiplayer)) need `aria-pressed` on the button element. `<Button>` declared `Element: null`, so there was no way to set it — which forced a choice: use `<Button>` and lose toggle semantics, or use a native `<button>` and lose the "why disabled" reason popover.

Follows on from #94 (`@onClick`).

## What's added

- **`<ToggleButton>`** (per review): a dedicated toggle component composed from `<Button>`. Required `@pressed: boolean` renders `aria-pressed="true"/"false"`; forwards `@disabled` / `@onClick` / `@variant` / `@start` / `@end` and splattributes. Exported from the package index, with tests and a docs page.
- **Splattributes on `<Button>`**: `Element: HTMLButtonElement` (replacing `Element: null`) with `...attributes` on the underlying `<button>`, placed after the component's own attributes so consumer attributes win on collision (`class` still merges). This is the seam that lets ToggleButton compose Button without duplicating the disabled-popover internals, and covers test selectors etc.
- A small CSS hook: `[aria-pressed="true"]` gets the same held-down look as `:active`, following the existing `[aria-disabled]` attribute-selector convention in `button.css`.
- Tests for both components: pressed state rendering + toggling, splatted attrs/class merge, `{{on "click"}}` via splattributes, `@disabled` still shows its reason popover.

```gjs
<ToggleButton
  @pressed={{this.muted}}
  @onClick={{this.toggleMute}}
  @disabled={{if this.noTrackSelected "Select a track first"}}
>
  Mute
</ToggleButton>
```

## Notes / tradeoffs

- **`@disabled` cannot suppress splatted listeners:** `@onClick` is suppressed while `@disabled` is set, but listeners attached via splattributes bind directly to the element, so the component can't intercept them — and since the button uses `aria-disabled` (not the `disabled` attribute, to keep the reason popover focusable), the browser doesn't block them either. A test documents this; guidance: use `@onClick` for actions that should be suppressed while disabled.
- **ToggleButton blocks:** named blocks can't be forwarded conditionally in Glimmer, so ToggleButton exposes only the default block; icons go through the `@start` / `@end` args.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
