### PR TITLE
Fix pre-existing CI failures (heading-order a11y audit; document typescript@rc breakage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,7 +121,7 @@ jobs:
           # lib/tsc entrypoint that ember-tsc requires, so this scenario fails.
           # It is allowed to fail via continue-on-error above.
           # https://github.com/NullVoxPopuli/nvp.ui/issues/98
-          - typescript@rc
+          # - typescript@rc
           # - typescript@next
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
           - typescript@5.9
           # typescript@rc is currently TypeScript 7, which no longer ships the
           # lib/tsc entrypoint that ember-tsc requires, so this scenario fails.
-          # It is allowed to fail via continue-on-error above.
+          # Disabled until glint supports TS 7:
           # https://github.com/NullVoxPopuli/nvp.ui/issues/98
           # - typescript@rc
           # - typescript@next

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,10 @@ jobs:
           - typescript@5.7
           - typescript@5.8
           - typescript@5.9
+          # typescript@rc is currently TypeScript 7, which no longer ships the
+          # lib/tsc entrypoint that ember-tsc requires, so this scenario fails.
+          # It is allowed to fail via continue-on-error above.
+          # https://github.com/NullVoxPopuli/nvp.ui/issues/98
           - typescript@rc
           # - typescript@next
 

--- a/public/docs/3-components/theme-toggle.gjs.md
+++ b/public/docs/3-components/theme-toggle.gjs.md
@@ -74,11 +74,11 @@ import { ComponentSignature } from "kolay";
 </template>
 ```
 
-## State Attributes
+### State Attributes
 
 none
 
-## Styling
+### Styling
 
 Public selectors:
 

--- a/public/docs/3-components/theme-toggle.gjs.md
+++ b/public/docs/3-components/theme-toggle.gjs.md
@@ -74,11 +74,11 @@ import { ComponentSignature } from "kolay";
 </template>
 ```
 
-### State Attributes
+## State Attributes
 
 none
 
-### Styling
+## Styling
 
 Public selectors:
 


### PR DESCRIPTION
Fixes the pre-existing CI failures on `main` (latest run: [29201377810](https://github.com/NullVoxPopuli/nvp.ui/actions/runs/29201377810)), which currently also block open PRs such as #96.

## Failing jobs, root causes, fixes

### 1. `ember-6.4.0` / `ember-latest` / `ember-beta` / `ember-alpha` / `Floating Dependencies` — axe `heading-order` violation

All five jobs fail the same single test:

```
not ok 17 ... Application | Pages: /Docs/3-components/theme-toggle
  [moderate]: Heading levels should only increase by one
  <h3 id="state-attributes">State Attributes</h3>
```

**Root cause:** kolay's `ComponentSignature` renders its "Element" heading as an `<h1>` mid-page. Its auto-leveling `Heading` (ember-primitives / which-heading-do-i-need) treats every `<section>` as a nesting boundary and only looks for heading context between the two nearest boundaries — and `<Load>`'s heading-less `<section>` wrapper isolates the signature's headings from the document, so the first one pins to level 1. On other component pages the signature also renders an `<h2>Arguments</h2>` after that `h1`, bridging back down before the markdown's `### State Attributes`; `ThemeToggle`'s signature has only an `Element`, so that page's document order is `h1 → h3` — a 2-level jump. These jobs install with `--no-lockfile` and pick up **axe-core 4.12**, whose `heading-order` rule catches this (the lockfile's 4.11 does not, which is why "Default Tests" passes).

**Fix (per review):** the markdown keeps its `### State Attributes` / `### Styling` (they're under "API Reference", so h3 is correct); the real fix is upstream in kolay: universal-ember/kolay#318 renders all signature headings (Element / Arguments / Blocks / Return) as siblings, one level below whatever heading precedes the api-docs block in document order — i.e. `h3` under an "API Reference" `h2`, with no stray `h1` and no per-union-variant level cascade.

> [!IMPORTANT]
> The a11y jobs on this PR will stay red until kolay#318 is merged **and released** (the failing jobs float kolay via `--no-lockfile`). Once a release ships, re-running CI here should be green with no further changes.

Verified end-to-end locally: packed kolay#318, overrode `kolay` in this repo, floating install (kolay 5.3.0 base + patch, axe-core 4.12.1) — full suite 83/83, including theme-toggle with h3 intact, and the timeline page (union signature — previously one heading-order violation away via a different kolay quirk) now renders a fully sequential hierarchy.

### 2. `typescript@rc` — TypeScript 7 removed `lib/tsc`

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/tsc' is not defined by "exports" in .../typescript/package.json
    at main (.../@glint/ember-tsc/lib/cli/run-volar-tsc.js:20:39)
```

**Root cause:** `typescript@rc` is now `7.0.1-rc` (the Go-based TS 7), which no longer ships the JS `./lib/tsc` entry that ember-tsc's Volar-based CLI (`runTsc(require.resolve('typescript/lib/tsc'), ...)`) requires. The latest `@glint/ember-tsc` (1.8.12) fails identically, so a dependency bump can't fix it — it needs upstream glint/volar support for TS 7.

**Fix (per review):** the scenario is commented out of the matrix until glint supports TS 7, with a comment linking #98 which tracks the upstream gap.

## Local verification

- Default (lockfile) suite: `pnpm build && pnpm test` — 83/83 pass; `pnpm lint` all green
- Floating repro (`pnpm install --no-lockfile`, axe-core 4.12.1): reproduced the exact theme-toggle failure, and 83/83 with kolay#318 applied
- Browser check with axe-core 4.12.1's `heading-order` rule directly: 0 violations on theme-toggle, button, and timeline pages with the kolay fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
