### PR TITLE
[Breaking] Remove @embroider/addon-shim

### DIFF
--- a/config/addon-main.cjs
+++ b/config/addon-main.cjs
@@ -1,6 +1,0 @@
-"use strict";
-
-const { dirname } = require("path");
-const { addonV1Shim } = require("@embroider/addon-shim");
-
-module.exports = addonV1Shim(dirname(__dirname));

--- a/package.json
+++ b/package.json
@@ -28,14 +28,12 @@
     "./test-support": {
       "types": "./declarations/test-support/index.d.ts",
       "default": "./dist/test-support/index.js"
-    },
-    "./addon-main": "./config/addon-main.cjs"
+    }
   },
   "files": [
     "dist",
     "declarations",
-    "src",
-    "config/addon-main.cjs"
+    "src"
   ],
   "scripts": {
     ":rollup": "rollup --config ./config/rollup.config.mjs",
@@ -69,7 +67,6 @@
   "dependencies": {
     "@ember/test-helpers": "^5.4.1",
     "@ember/test-waiters": ">= 4.1.0",
-    "@embroider/addon-shim": "^1.10.2",
     "@embroider/macros": "1.20.2",
     "@glimmer/component": "^2.0.0",
     "@glint/template": "^1.7.7",
@@ -168,8 +165,6 @@
   },
   "ember-addon": {
     "version": 2,
-    "type": "addon",
-    "main": "config/addon-main.cjs",
-    "app-js": {}
+    "type": "addon"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,9 +27,6 @@ importers:
       '@ember/test-waiters':
         specifier: '>= 4.1.0'
         version: 4.1.1(e36bea8b02087eee87d28ed2727a0989)
-      '@embroider/addon-shim':
-        specifier: ^1.10.2
-        version: 1.10.2
       '@embroider/macros':
         specifier: 1.20.2
         version: 1.20.2(e36bea8b02087eee87d28ed2727a0989)


### PR DESCRIPTION
Removes `@embroider/addon-shim`, per request.

## What's removed

- `@embroider/addon-shim` from `dependencies`
- `config/addon-main.cjs` (the `addonV1Shim` entry point)
- the `"./addon-main"` export and its `files` entry
- `ember-addon.main` — only ever read by classic ember-cli
- `ember-addon."app-js"` — it was empty, and every read of `app-js` in `@embroider/core` (module-resolver.js, app-files.js) is `if (appJS)`-guarded, so omitting it is safe

## What's deliberately kept

`keywords: ["ember-addon"]` and `ember-addon: { "version": 2, "type": "addon" }` — `@embroider/shared-internals`' `Package#isV2Addon()` classifies packages via exactly these three signals (`isEmberPackage()` checks the keyword; `isV2Ember()` checks `ember-addon.version === 2`; then `type === "addon"`). Removing them would make embroider treat nvp.ui as a plain npm package.

## Tradeoff

The shim is the only thing that lets **classic (broccoli/ember-cli) builds** auto-discover a v2 addon. After this change, a classic-build app that installs nvp.ui gets nothing from it. That seems acceptable here: the get-started docs already state **"Compatibility: Vite 5+"**, the docs app and test suite are all vite, and embroider/vite consumers resolve everything through package `exports`, which are untouched.

## Verification

- `pnpm build` (incl. declarations), all 6 `lint:*` scripts, and the full test suite (96/96) pass; the docs app builds and serves. (Local note: the rollup declarations step trips over a machine-local stale corepack pnpm 10.2.1 that predates `packages`-less `pnpm-workspace.yaml`; worked around with a local `node_modules/.bin/pnpm` shim — CI's pnpm is unaffected.)
- **Real consuming app**: generated a fresh app with `ember.nvp` (ember-source 7.0.0, vite 8, `ember-strict-application-resolver`, `@nullvoxpopuli/ember-vite`), installed the packed tarball of shimless nvp.ui (verified the tarball contains zero addon-shim/addon-main traces), imported `Button`, `ToggleButton`, and `Shell` in `application.gjs`:
  - `pnpm build` succeeds; the production bundle contains nvp.ui's JS and CSS
  - added rendering tests (Button renders + `@onClick` fires, ToggleButton renders `aria-pressed`, Shell renders and syncs the theme class onto `body`) — all pass via `pnpm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
