### PR TITLE
Fix menu styling: opaque elevated surface, trigger alignment, and theme-aware details

### DIFF
--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -62,14 +62,49 @@
   }
 }
 
+/**
+ * Popovers float over arbitrary content, so unlike inline surfaces the
+ * background must be opaque. In light mode the surface math produces a
+ * translucent color (the mix percentages sum to < 100%), which would let
+ * the page bleed through the menu. Re-layering the surface tint over the
+ * page background keeps the same "elevated surface" color, but opaque.
+ * (The extra .surface class wins over the .theme-light .surface variables.)
+ */
+.nvp__menu__content.surface,
+.nvp__menu__kbd-hints.surface {
+  background-color: color-mix(
+    in oklab,
+    var(--color-page-background),
+    var(--surface-nesting-color-mix) var(--surface-nesting)
+  );
+}
+
 .nvp__menu__content {
+  --menu-border-color: color-mix(in oklab, var(--surface-background-color) 100%, black 30%);
+
   anchor-name: --nvp-menu;
-  min-width: 10rem;
+  min-width: 12rem;
   border-radius: var(--radius);
-  border: var(--border-width) var(--border-style) var(--border-color);
-  padding: 0;
+  border: var(--border-width) var(--border-style) var(--menu-border-color);
+
+  /**
+   * Breathing room around the items so that item hover backgrounds
+   * don't square off the rounded corners of the menu, and so the
+   * focus ring has space (see the note in focus.css).
+   */
+  padding: var(--padding-1);
   z-index: var(--z-hover);
-  background: var(--color-page-background);
+
+  /* Enter transition (--fade-duration is 0s under prefers-reduced-motion) */
+  transform-origin: top;
+  transition:
+    opacity var(--fade-duration),
+    scale var(--fade-duration);
+
+  @starting-style {
+    opacity: 0;
+    scale: 0.98;
+  }
 }
 
 .nvp__menu__item,
@@ -78,8 +113,9 @@
   width: 100%;
   padding: var(--padding-1) var(--padding-3);
   border: none;
+  border-radius: var(--radius);
   background: transparent;
-  color: var(--color-text);
+  color: color-mix(in oklab, var(--color-text) 90%, transparent);
   text-align: left;
   cursor: pointer;
   font-family: var(--font);
@@ -88,17 +124,30 @@
   text-decoration: none;
   transition: background 0.1s;
 
+  /**
+   * The menu focuses items on hover (and keeps them focused when the
+   * pointer leaves), so :focus is the "highlighted item" state.
+   * Keyboard navigation additionally gets the focus ring via the
+   * global :focus-visible styles in focus.css.
+   */
   &:hover,
+  &:focus,
   &:focus-visible {
     background: color-mix(in oklab, var(--color-primary) 20%, transparent);
     outline: none;
+  }
+
+  &:active {
+    background: color-mix(in oklab, var(--color-primary) 35%, transparent);
   }
 }
 
 .nvp__menu__separator {
   height: 1px;
-  margin: var(--padding-1) 0;
-  background: var(--border-color);
+
+  /* full-bleed hairline: extends through the content's padding */
+  margin: var(--padding-1) calc(-1 * var(--padding-1));
+  background: color-mix(in oklab, var(--color-text) 12%, transparent);
 }
 
 .nvp__menu__kbd-hints {
@@ -109,8 +158,10 @@
   translate: calc(-100% - 0.25rem) 0;
   width: max-content;
   z-index: calc(var(--z-hover) - 1);
+  border: var(--border-width) var(--border-style)
+    color-mix(in oklab, var(--surface-background-color) 100%, black 30%);
+  border-top: none;
   border-radius: 0 0 var(--radius) var(--radius);
-  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.06);
   padding: 0.15rem 0.5rem 0.25rem 0.5rem;
   font-size: 0.6rem;
   color: color-mix(in oklab, var(--color-text) 60%, transparent);
@@ -118,13 +169,11 @@
 
   .ember-primitives__key {
     text-transform: uppercase;
-    background-color: #eee;
+    background-color: color-mix(in oklab, var(--color-text) 12%, var(--surface-background-color));
     border-radius: 2px;
-    border: 1px solid #b4b4b4;
-    box-shadow:
-      0 1px 1px rgba(0, 0, 0, 0.2),
-      0 2px 0 0 rgba(255, 255, 255, 0.7) inset;
-    color: #333;
+    border: 1px solid color-mix(in oklab, var(--color-text) 35%, transparent);
+    box-shadow: 0 1px 1px color-mix(in oklab, var(--color-text) 20%, transparent);
+    color: color-mix(in oklab, var(--color-text) 80%, transparent);
     display: inline-block;
     font-size: 0.55rem;
     font-weight: 700;
@@ -135,6 +184,13 @@
 }
 
 @media (pointer: coarse) {
+  .nvp__menu__kbd-hints {
+    display: none;
+  }
+}
+
+/* The hints are positioned with CSS anchor positioning */
+@supports not (anchor-name: --nvp-menu) {
   .nvp__menu__kbd-hints {
     display: none;
   }

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -22,6 +22,8 @@ export interface Signature {
     /**
      * Placement of the menu content relative to the trigger.
      * Uses floating-ui placement values.
+     *
+     * Defaults to "bottom-start" (aligned with the left edge of the trigger).
      */
     placement?: string;
   };
@@ -55,7 +57,11 @@ export interface Signature {
 }
 
 export const Menu: TOC<Signature> = <template>
-  <PrimitiveMenu @placement={{@placement}} as |menu|>
+  <PrimitiveMenu
+    @placement={{if @placement @placement "bottom-start"}}
+    @offsetOptions={{6}}
+    as |menu|
+  >
     {{yield
       (hash
         Trigger=(component StyledTrigger Trigger=menu.Trigger variant=@variant)
@@ -72,7 +78,7 @@ const StyledTrigger = <template>
 </template>;
 
 const StyledContent = <template>
-  <@Content class="nvp__menu__content surface elevation-lg" ...attributes as |items|>
+  <@Content class="nvp__menu__content surface elevation-xl" ...attributes as |items|>
     {{yield
       (hash
         Item=(component StyledItem Item=items.Item)

--- a/tests/components/menu-test.gts
+++ b/tests/components/menu-test.gts
@@ -47,6 +47,27 @@ module("Menu", function (hooks) {
     assert.dom(".nvp__menu__item").hasText("Item 1");
   });
 
+  test("content is a styled, elevated surface", async function (assert) {
+    await render(
+      <template>
+        <PortalTargets />
+        <Menu as |menu|>
+          <menu.Trigger>Open</menu.Trigger>
+          <menu.Content as |Items|>
+            <Items.Item>Item 1</Items.Item>
+          </menu.Content>
+        </Menu>
+      </template>,
+    );
+
+    await click(".nvp__menu__trigger");
+
+    assert.dom(".nvp__menu__content").hasClass("surface");
+    assert.dom(".nvp__menu__content").hasClass("elevation-xl");
+    assert.dom(".nvp__menu__content").hasAttribute("role", "menu");
+    assert.dom(".nvp__menu__item").hasAttribute("role", "menuitem");
+  });
+
   test("renders keyboard hints when open", async function (assert) {
     await render(
       <template>


### PR DESCRIPTION
Fixes the styling of the `Menu` component.

## What was broken (verified by running the docs app and opening the menus in both themes)

| | |
|---|---|
| **Placement** | floating-ui defaulted to centered `bottom`, so the open menu was not aligned with the trigger's edge, and it sat flush against the trigger (0px gap). |
| **Surface** | `.nvp__menu__content` set `background: var(--color-page-background)`, clobbering the `.surface` background. The menu didn't read as elevated — in dark mode it was *darker* than the card it floated over. |
| **Translucency (light mode)** | The light-theme `.surface` math produces a translucent color (the `color-mix` percentages sum to 70%), so page content visibly bled through the floating menu ("Last action: …" was readable through the items). |
| **Items** | Flush with the content border (no inner padding): hover backgrounds squared off the popover's rounded corners, and the global focus ring (`--ring-shadow`) had no breathing room — focus.css itself documents that interactives need ≥ 4px from a hard boundary. |
| **Separator** | Used `--border-color` (`#efefef` / `#222`), which is invisible against the menu surface in both themes. |
| **Kbd hint** | The "press ESC to close" tab used hardcoded light colors (`#eee` background, `#333` text) — broken in dark mode. |

## What changed

`src/components/menu.gts`
- `@placement` now defaults to `bottom-start`; `@offsetOptions={{6}}` adds a 6px gap from the trigger (both forwarded to ember-primitives' floating-ui `Popover`)
- content elevation bumped `elevation-lg` → `elevation-xl` (popovers float above everything else)

`src/components/menu.css`
- content keeps the `.surface` tint but re-layers it over `--color-page-background` (`color-mix(in oklab, var(--color-page-background), var(--surface-nesting-color-mix) var(--surface-nesting))`) so the popover is always **opaque** while still following the surface-nesting system
- border follows the tabs-panel convention: `color-mix(in oklab, var(--surface-background-color) 100%, black 30%)`
- content gets `var(--padding-1)` inner padding; items get `var(--radius)` corners, a `:focus` highlight (the primitives menu focuses items on hover), a stronger `:active` state, and room for the keyboard `:focus-visible` ring
- separator is a full-bleed hairline derived from `--color-text` (visible in both themes)
- kbd-hint colors derive from `--color-text` + the surface color; hint hidden via `@supports not (anchor-name: …)` in browsers without CSS anchor positioning
- subtle `@starting-style` fade/scale entrance, driven by `--fade-duration` (0s under `prefers-reduced-motion`)

Tokens used: `--radius`, `--padding-1/3`, `--border-width/style`, `--color-text`, `--color-primary`, `--color-page-background`, `--surface-*`, `--fade-duration`, `--z-hover`, plus the `surface` / `elevation-xl` classes.

## Verification

- Before/after screenshots of the open menu on the docs landing-page showcase (BrowserWindow demo), light + dark: alignment, opacity, separator, and hint all verified visually. The Vercel preview shows it live (landing page "Actions" menu, and `/Docs/3-components/menu`).
- Keyboard nav: arrowing through items shows the kit's focus ring fully contained inside the popover in both themes.
- `pnpm lint` — all green (format, hbs, js, types, package, published-types)
- `pnpm test` — 97/97 passing, including the new "content is a styled, elevated surface" test and the per-page axe audits of every docs page in default/dark/light themes
- Floating-deps run: `pnpm install --no-lockfile` + full test suite — 97/97 passing

Note: local build needed the known machine workaround of shimming `node_modules/.bin/pnpm` to the proto pnpm (stale corepack pnpm 10.2.1 answers `pnpm` inside rollup's declarations plugin with "packages field missing"); no repo changes were made for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
