### PR TITLE
Add <Navigation> + <NavigationList>: a nav landmark that owns layout, and a list that is just a <ul>

### DIFF
--- a/docs-app/docs.css
+++ b/docs-app/docs.css
@@ -184,8 +184,11 @@
   font-weight: 600;
 }
 
+/* Prose rules steer clear of <NavigationList> demos --
+   the component owns the styling of its own lists */
+
 .nvp__application-shell__content p,
-.nvp__application-shell__content li {
+.nvp__application-shell__content li:not(.nvp__navigation-list *) {
   line-height: 1.65;
 }
 
@@ -193,17 +196,17 @@
   margin-block: 0.75rem;
 }
 
-.nvp__application-shell__content ul,
+.nvp__application-shell__content ul:not(.nvp__navigation-list *),
 .nvp__application-shell__content ol {
   padding-left: 1.375rem;
   margin-block: 0.75rem;
 }
 
-.nvp__application-shell__content li {
+.nvp__application-shell__content li:not(.nvp__navigation-list *) {
   margin-block: 0.3125rem;
 }
 
-.nvp__application-shell__content li > ul,
+.nvp__application-shell__content li > ul:not(.nvp__navigation-list *),
 .nvp__application-shell__content li > ol {
   margin-block: 0.3125rem;
 }

--- a/docs-app/docs.css
+++ b/docs-app/docs.css
@@ -89,59 +89,7 @@
   padding: 1.25rem 0.75rem;
 }
 
-aside.docs-nav nav ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  line-height: 1.5;
-}
-
-/* Group labels are rendered as text (or an index link) directly
-   inside the top-level list items */
-aside.docs-nav nav > ul > li {
-  margin-top: 1.5rem;
-  font-size: 0.6875rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--docs-muted);
-}
-
-aside.docs-nav nav > ul > li:first-child {
-  margin-top: 0;
-}
-
-/* ...while the pages within a group reset back to normal text */
-aside.docs-nav nav > ul > li > ul {
-  margin-top: 0.5rem;
-  font-size: 0.9375rem;
-  font-weight: 400;
-  letter-spacing: normal;
-  text-transform: none;
-  color: var(--color-text);
-}
-
-aside.docs-nav nav a {
-  display: block;
-  padding: 0.3125rem 0.625rem;
-  border-radius: calc(2 * var(--radius));
-  color: color-mix(in oklab, var(--color-text) 78%, transparent);
-  text-decoration: none;
-  transition:
-    background-color var(--fade-duration),
-    color var(--fade-duration);
-}
-
-aside.docs-nav nav a:hover {
-  background: var(--docs-faint);
-  color: var(--color-text);
-}
-
-aside.docs-nav nav a.active {
-  background: color-mix(in oklab, var(--color-primary) 24%, transparent);
-  color: var(--color-text);
-  font-weight: 500;
-}
+/* The nav-list styling itself comes from <NavigationList> */
 
 .docs-nav__meta {
   margin-top: 2rem;
@@ -260,13 +208,13 @@ aside.docs-nav nav a.active {
   margin-block: 0.3125rem;
 }
 
-.nvp__application-shell__content :is(p, li, td) a:not(.nvp__button) {
+.nvp__application-shell__content :is(p, li, td) a:not(.nvp__button, .nvp__navigation-list a) {
   color: var(--docs-link);
   text-decoration-thickness: 1px;
   text-underline-offset: 3px;
 }
 
-.nvp__application-shell__content :is(p, li, td) a:not(.nvp__button):hover {
+.nvp__application-shell__content :is(p, li, td) a:not(.nvp__button, .nvp__navigation-list a):hover {
   text-decoration-thickness: 2px;
 }
 

--- a/docs-app/docs.css
+++ b/docs-app/docs.css
@@ -69,27 +69,13 @@
 
 /* ────────────────────────────────────────────
    Side navigation
-   (shared by the desktop sidebar and the mobile tray)
+   (<Navigation> owns stickiness/scroll/padding;
+   <NavigationList> owns the lists themselves)
    ──────────────────────────────────────────── */
 
 .nvp__application-shell__sidebar {
   border-right: var(--docs-border);
 }
-
-.nvp__application-shell__layout .nvp__application-shell__sidebar aside.docs-nav {
-  position: sticky;
-  top: var(--docs-header-height, 3.5rem);
-  max-height: calc(100dvh - var(--docs-header-height, 3.5rem));
-  overflow-y: auto;
-  padding: 1.5rem 1rem 2rem 1.25rem;
-  min-width: 14rem;
-}
-
-.mobile-menu__tray aside.docs-nav {
-  padding: 1.25rem 0.75rem;
-}
-
-/* The nav-list styling itself comes from <NavigationList> */
 
 .docs-nav__meta {
   margin-top: 2rem;
@@ -196,7 +182,7 @@
   margin-block: 0.75rem;
 }
 
-.nvp__application-shell__content ul:not(.nvp__navigation-list *),
+.nvp__application-shell__content ul:not(.nvp__navigation-list, .nvp__navigation-list *),
 .nvp__application-shell__content ol {
   padding-left: 1.375rem;
   margin-block: 0.75rem;

--- a/docs-app/templates/application.gts
+++ b/docs-app/templates/application.gts
@@ -8,15 +8,22 @@ import { pageTitle } from "ember-page-title";
 import Route from "ember-route-template";
 import { docsManager, isCollection, isIndex } from "kolay";
 
-import { ApplicationShell, ExternalLink, NavigationList, ThemeToggle } from "#src/index.ts";
+import {
+  ApplicationShell,
+  ExternalLink,
+  Navigation,
+  NavigationList,
+  ThemeToggle,
+} from "#src/index.ts";
 import { abbreviatedSha } from "~build/git";
 
 import type RouterService from "@ember/routing/router-service";
 import type { Collection, Page } from "kolay";
 
 /**
- * The sidebar composes <NavigationList> directly from kolay's
- * docs manifest: one Section per collection, one entry per page.
+ * The sidebar composes <Navigation> + <NavigationList> directly from
+ * kolay's docs manifest: one labelled list per collection, one entry
+ * per page. Kolay is data-only here.
  */
 class SideNav extends Component<{ Element: HTMLElement }> {
   @service declare router: RouterService;
@@ -36,24 +43,26 @@ class SideNav extends Component<{ Element: HTMLElement }> {
   isCurrent = (page: Page) => {
     if (page.path === "/") return false;
 
-    return this.router.currentURL?.startsWith(page.path) ?? false;
+    const url = this.router.currentURL?.split(/[?#]/)[0];
+
+    // Match whole path segments, so that e.g. /navigation is not
+    // considered "current" while viewing /navigation-list
+    return url === page.path || (url?.startsWith(`${page.path}/`) ?? false);
   };
 
   <template>
-    <aside class="docs-nav">
-      <NavigationList aria-label="Documentation" ...attributes as |list|>
-        {{#each this.groups as |group|}}
-          <list.Section @label={{groupName group.name}}>
-            {{#each (pagesOf group) as |page|}}
-              <li>
-                <a href={{page.path}} aria-current={{if (this.isCurrent page) "page"}}>
-                  {{nameFor page}}
-                </a>
-              </li>
-            {{/each}}
-          </list.Section>
-        {{/each}}
-      </NavigationList>
+    <Navigation aria-label="Documentation" ...attributes>
+      {{#each this.groups as |group|}}
+        <NavigationList @label={{groupName group.name}}>
+          {{#each (pagesOf group) as |page|}}
+            <li>
+              <a href={{page.path}} aria-current={{if (this.isCurrent page) "page"}}>
+                {{nameFor page}}
+              </a>
+            </li>
+          {{/each}}
+        </NavigationList>
+      {{/each}}
 
       <p class="docs-nav__meta">
         Built from
@@ -61,7 +70,7 @@ class SideNav extends Component<{ Element: HTMLElement }> {
           {{abbreviatedSha}}
         </a>
       </p>
-    </aside>
+    </Navigation>
   </template>
 }
 

--- a/docs-app/templates/application.gts
+++ b/docs-app/templates/application.gts
@@ -5,7 +5,7 @@ import { pageTitle } from "ember-page-title";
 import Route from "ember-route-template";
 import { PageNav } from "kolay/components";
 
-import { ApplicationShell, ExternalLink, ThemeToggle } from "#src/index.ts";
+import { ApplicationShell, ExternalLink, NavigationList, ThemeToggle } from "#src/index.ts";
 import { abbreviatedSha } from "~build/git";
 
 import type { TOC } from "@ember/component/template-only";
@@ -13,22 +13,26 @@ import type { Page } from "kolay";
 
 const SideNav: TOC<{ Element: HTMLElement }> = <template>
   <aside class="docs-nav">
-    <PageNav ...attributes>
-      <:page as |x|>
-        <x.Link>
-          {{nameFor x.page}}
-        </x.Link>
-      </:page>
-      <:collection as |x|>
-        {{#if x.index}}
-          <x.index.Link>
-            {{groupName x.collection.name}}
-          </x.index.Link>
-        {{else}}
-          {{groupName x.collection.name}}
-        {{/if}}
-      </:collection>
-    </PageNav>
+    <NavigationList>
+      <:nav>
+        <PageNav ...attributes>
+          <:page as |x|>
+            <x.Link>
+              {{nameFor x.page}}
+            </x.Link>
+          </:page>
+          <:collection as |x|>
+            {{#if x.index}}
+              <x.index.Link>
+                {{groupName x.collection.name}}
+              </x.index.Link>
+            {{else}}
+              {{groupName x.collection.name}}
+            {{/if}}
+          </:collection>
+        </PageNav>
+      </:nav>
+    </NavigationList>
 
     <p class="docs-nav__meta">
       Built from

--- a/docs-app/templates/application.gts
+++ b/docs-app/templates/application.gts
@@ -1,47 +1,69 @@
 import "../docs.css";
 
+import Component from "@glimmer/component";
+import { service } from "@ember/service";
+
 import { pascalCase, sentenceCase } from "change-case";
 import { pageTitle } from "ember-page-title";
 import Route from "ember-route-template";
-import { PageNav } from "kolay/components";
+import { docsManager, isCollection, isIndex } from "kolay";
 
 import { ApplicationShell, ExternalLink, NavigationList, ThemeToggle } from "#src/index.ts";
 import { abbreviatedSha } from "~build/git";
 
-import type { TOC } from "@ember/component/template-only";
-import type { Page } from "kolay";
+import type RouterService from "@ember/routing/router-service";
+import type { Collection, Page } from "kolay";
 
-const SideNav: TOC<{ Element: HTMLElement }> = <template>
-  <aside class="docs-nav">
-    <NavigationList>
-      <:nav>
-        <PageNav ...attributes>
-          <:page as |x|>
-            <x.Link>
-              {{nameFor x.page}}
-            </x.Link>
-          </:page>
-          <:collection as |x|>
-            {{#if x.index}}
-              <x.index.Link>
-                {{groupName x.collection.name}}
-              </x.index.Link>
-            {{else}}
-              {{groupName x.collection.name}}
-            {{/if}}
-          </:collection>
-        </PageNav>
-      </:nav>
-    </NavigationList>
+/**
+ * The sidebar composes <NavigationList> directly from kolay's
+ * docs manifest: one Section per collection, one entry per page.
+ */
+class SideNav extends Component<{ Element: HTMLElement }> {
+  @service declare router: RouterService;
 
-    <p class="docs-nav__meta">
-      Built from
-      <a href="https://github.com/NullVoxPopuli/nvp.ui/commit/{{abbreviatedSha}}">
-        {{abbreviatedSha}}
-      </a>
-    </p>
-  </aside>
-</template>;
+  get docs() {
+    return docsManager(this);
+  }
+
+  get groups(): Collection[] {
+    const tree = this.docs.tree;
+
+    if (!("pages" in tree)) return [];
+
+    return tree.pages.filter((page) => isCollection(page));
+  }
+
+  isCurrent = (page: Page) => {
+    if (page.path === "/") return false;
+
+    return this.router.currentURL?.startsWith(page.path) ?? false;
+  };
+
+  <template>
+    <aside class="docs-nav">
+      <NavigationList aria-label="Documentation" ...attributes as |list|>
+        {{#each this.groups as |group|}}
+          <list.Section @label={{groupName group.name}}>
+            {{#each (pagesOf group) as |page|}}
+              <li>
+                <a href={{page.path}} aria-current={{if (this.isCurrent page) "page"}}>
+                  {{nameFor page}}
+                </a>
+              </li>
+            {{/each}}
+          </list.Section>
+        {{/each}}
+      </NavigationList>
+
+      <p class="docs-nav__meta">
+        Built from
+        <a href="https://github.com/NullVoxPopuli/nvp.ui/commit/{{abbreviatedSha}}">
+          {{abbreviatedSha}}
+        </a>
+      </p>
+    </aside>
+  </template>
+}
 
 export default Route(
   <template>
@@ -72,6 +94,10 @@ export default Route(
     </style>
   </template>,
 );
+
+function pagesOf(group: Collection): Page[] {
+  return group.pages.filter((page): page is Page => !isCollection(page) && !isIndex(page));
+}
 
 /**
  * Collection directories are prefixed with a number to control

--- a/public/docs/3-components/navigation-list.gjs.md
+++ b/public/docs/3-components/navigation-list.gjs.md
@@ -1,9 +1,9 @@
 # NavigationList
 
-A styled container for navigation lists -- sidebars, docs navs, tables of contents.
+A styled navigation list -- for sidebars, docs navs, tables of contents.
 It provides the list structure (spacing, uppercase section labels) and the link
 styling ("chip" hover + current-page highlight), while you bring your own links:
-plain `<a>`, `<LinkTo>`, ember-primitives links, and generated navs all work.
+plain `<a>`, `<LinkTo>`, and ember-primitives links all work.
 
 This very docs site's sidebar is a `NavigationList`.
 
@@ -26,15 +26,15 @@ const Link = <template>
 
 <template>
   <NavigationList aria-label="Demo: documentation" as |l|>
-    <l.Section @label="Get started" as |s|>
-      <s.Item><Link @href="#intro">Intro</Link></s.Item>
-      <s.Item><Link @href="#theme">Theme</Link></s.Item>
-      <s.Item><Link @href="#surfaces">Surfaces</Link></s.Item>
+    <l.Section @label="Get started">
+      <li><Link @href="#intro">Intro</Link></li>
+      <li><Link @href="#theme">Theme</Link></li>
+      <li><Link @href="#surfaces">Surfaces</Link></li>
     </l.Section>
-    <l.Section @label="Components" as |s|>
-      <s.Item><Link @href="#button">Button</Link></s.Item>
-      <s.Item><Link @href="#menu">Menu</Link></s.Item>
-      <s.Item><Link @href="#timeline">Timeline</Link></s.Item>
+    <l.Section @label="Components">
+      <li><Link @href="#button">Button</Link></li>
+      <li><Link @href="#menu">Menu</Link></li>
+      <li><Link @href="#timeline">Timeline</Link></li>
     </l.Section>
   </NavigationList>
 
@@ -53,57 +53,18 @@ const Link = <template>
 Give the current page's link an `aria-current` attribute -- that's both the
 accessible way to convey "you are here" _and_ the styling hook. Links with an
 `active` class are highlighted too, for link components that set one
-(ember's `<LinkTo>`, kolay's `PageNav`, ...).
+(ember's `<LinkTo>`, ...).
 
 ```gjs live no-shadow
 import { NavigationList } from "nvp.ui";
 
 <template>
   <NavigationList aria-label="Demo: current page" as |l|>
-    <l.Section as |s|>
-      <s.Item><a href="#overview">Overview</a></s.Item>
-      <s.Item><a href="#usage" aria-current="page">Usage</a></s.Item>
-      <s.Item><a href="#api">API</a></s.Item>
+    <l.Section>
+      <li><a href="#overview">Overview</a></li>
+      <li><a href="#usage" aria-current="page">Usage</a></li>
+      <li><a href="#api">API</a></li>
     </l.Section>
-  </NavigationList>
-
-  <style>
-    @scope {
-      .nvp__navigation-list {
-        max-width: 14rem;
-      }
-    }
-  </style>
-</template>
-```
-
-## Bring your own nav
-
-Some tools render a whole `<nav>` for you (this site's sidebar uses
-[kolay](https://github.com/NullVoxPopuli/kolay)'s `PageNav`, which generates the
-nav from the docs' folder structure). Rendering a second `<nav>` around that
-would create a nested navigation landmark, so the `<:nav>` block renders a
-plain styling container instead. Text (or a link) directly inside a top-level
-`<li>` gets the section-label treatment.
-
-```gjs live no-shadow
-import { NavigationList } from "nvp.ui";
-
-<template>
-  <NavigationList>
-    <:nav>
-      <nav aria-label="Demo: bring your own nav">
-        <ul>
-          <li>
-            Generated group
-            <ul>
-              <li><a href="#one" class="active">Page one</a></li>
-              <li><a href="#two">Page two</a></li>
-            </ul>
-          </li>
-        </ul>
-      </nav>
-    </:nav>
   </NavigationList>
 
   <style>
@@ -129,27 +90,30 @@ import { NavigationList } from "nvp.ui/navigation-list";
 
 <template>
   <NavigationList aria-label="Documentation" as |l|>
-    <l.Section @label="Group label" as |s|>
-      <s.Item><a href="/somewhere">Link goes here</a></s.Item>
+    <l.Section @label="Group label">
+      <li><a href="/somewhere">Link goes here</a></li>
     </l.Section>
   </NavigationList>
 </template>
 ```
 
-`Section` groups links under an optional uppercase label; `Item` is the `<li>`
-wrapper for a single entry. The link element itself is always yours.
+`Section` renders one `<ul>` of links under an optional uppercase label. Its
+children are plain `<li>` elements that you render yourself -- the stylesheet
+targets the direct-descendant `li`s and the links inside them, so the link
+element is always yours.
 
 ## Accessibility
 
 - the component renders a real `<nav>` + `<ul>`/`<li>` structure, so assistive
   technology announces it as a navigation landmark containing lists
 - pass an `aria-label` whenever a page has more than one `<nav>`
-- section labels are styled text, not headings, so they never break the page's
+- a section's `@label` is programmatically associated with its list via
+  `aria-labelledby`, so screen readers announce the list by its group name
+  (e.g. "Get started, list, 3 items")
+- labels are styled text, not headings, so they never break the page's
   heading outline
 - prefer `aria-current="page"` on the current link -- the visual highlight and
   the announced state then come from the same attribute
-- the `<:nav>` block exists so that content which already renders a `<nav>`
-  isn't wrapped in a second, nested navigation landmark
 
 ## API Reference
 
@@ -179,20 +143,6 @@ import { ComponentSignature } from "kolay";
 </template>
 ```
 
-### Item (yielded)
-
-```gjs live no-shadow
-import { ComponentSignature } from "kolay";
-
-<template>
-  <ComponentSignature
-    @package="."
-    @module="declarations/components/navigation-list"
-    @name="ItemSignature"
-  />
-</template>
-```
-
 ### CSS Custom Properties
 
 |                Property                |                  Default                  | Description                           |
@@ -201,17 +151,17 @@ import { ComponentSignature } from "kolay";
 |     `--navigation-list-link-color`     |  `color-mix(… var(--color-text) 78% …)`   | Resting link color                    |
 |  `--navigation-list-hover-background`  |   `color-mix(… var(--color-text) 7% …)`   | Link hover background                 |
 | `--navigation-list-current-background` | `color-mix(… var(--color-primary) 24% …)` | Current-page link background          |
-|    `--navigation-list-section-gap`     |          `calc(6 * var(--gap))`           | Gap between sections                  |
-|     `--navigation-list-label-gap`      |              `var(--gap-2)`               | Gap between a label and its links     |
-|      `--navigation-list-item-gap`      |                   `0px`                   | Extra gap between links               |
+|    `--navigation-list-section-gap`     |          `calc(12 * var(--gap))`          | Gap between sections                  |
+|     `--navigation-list-label-gap`      |              `var(--gap-4)`               | Gap between a label and its links     |
+|      `--navigation-list-item-gap`      |         `calc(2.5 * var(--gap))`          | Gap between links                     |
+|       `--navigation-list-indent`       |              `var(--gap-2)`               | List indentation under the label      |
 |    `--navigation-list-item-padding`    |       derived from `--padding-1/2`        | Link padding (makes the hover "chip") |
 |    `--navigation-list-item-radius`     |         `calc(2 * var(--radius))`         | Link corner radius                    |
 
 ### CSS Classes
 
-|              Class               | Description                             |
-| :------------------------------: | :-------------------------------------- |
-|     `.nvp__navigation-list`      | The `<nav>` (or the `<:nav>` container) |
-| `.nvp__navigation-list__section` | One group of links                      |
-|  `.nvp__navigation-list__label`  | The uppercase section label             |
-|  `.nvp__navigation-list__item`   | The `<li>` around each link             |
+|              Class               | Description                   |
+| :------------------------------: | :---------------------------- |
+|     `.nvp__navigation-list`      | The `<nav>`                   |
+| `.nvp__navigation-list__section` | One group of links (a `<ul>`) |
+|  `.nvp__navigation-list__label`  | The uppercase section label   |

--- a/public/docs/3-components/navigation-list.gjs.md
+++ b/public/docs/3-components/navigation-list.gjs.md
@@ -1,0 +1,217 @@
+# NavigationList
+
+A styled container for navigation lists -- sidebars, docs navs, tables of contents.
+It provides the list structure (spacing, uppercase section labels) and the link
+styling ("chip" hover + current-page highlight), while you bring your own links:
+plain `<a>`, `<LinkTo>`, ember-primitives links, and generated navs all work.
+
+This very docs site's sidebar is a `NavigationList`.
+
+```gjs live no-shadow
+import { NavigationList } from "nvp.ui";
+import { cell } from "ember-resources";
+import { fn } from "@ember/helper";
+import { on } from "@ember/modifier";
+
+const current = cell("#intro");
+const ariaCurrent = (href) => (current.current === href ? "page" : undefined);
+const goTo = (href, event) => {
+  event.preventDefault();
+  current.set(href);
+};
+
+const Link = <template>
+  <a href={{@href}} aria-current={{ariaCurrent @href}} {{on "click" (fn goTo @href)}}>{{yield}}</a>
+</template>;
+
+<template>
+  <NavigationList aria-label="Demo: documentation" as |l|>
+    <l.Section @label="Get started" as |s|>
+      <s.Item><Link @href="#intro">Intro</Link></s.Item>
+      <s.Item><Link @href="#theme">Theme</Link></s.Item>
+      <s.Item><Link @href="#surfaces">Surfaces</Link></s.Item>
+    </l.Section>
+    <l.Section @label="Components" as |s|>
+      <s.Item><Link @href="#button">Button</Link></s.Item>
+      <s.Item><Link @href="#menu">Menu</Link></s.Item>
+      <s.Item><Link @href="#timeline">Timeline</Link></s.Item>
+    </l.Section>
+  </NavigationList>
+
+  <style>
+    @scope {
+      .nvp__navigation-list {
+        max-width: 14rem;
+      }
+    }
+  </style>
+</template>
+```
+
+## Marking the current page
+
+Give the current page's link an `aria-current` attribute -- that's both the
+accessible way to convey "you are here" _and_ the styling hook. Links with an
+`active` class are highlighted too, for link components that set one
+(ember's `<LinkTo>`, kolay's `PageNav`, ...).
+
+```gjs live no-shadow
+import { NavigationList } from "nvp.ui";
+
+<template>
+  <NavigationList aria-label="Demo: current page" as |l|>
+    <l.Section as |s|>
+      <s.Item><a href="#overview">Overview</a></s.Item>
+      <s.Item><a href="#usage" aria-current="page">Usage</a></s.Item>
+      <s.Item><a href="#api">API</a></s.Item>
+    </l.Section>
+  </NavigationList>
+
+  <style>
+    @scope {
+      .nvp__navigation-list {
+        max-width: 14rem;
+      }
+    }
+  </style>
+</template>
+```
+
+## Bring your own nav
+
+Some tools render a whole `<nav>` for you (this site's sidebar uses
+[kolay](https://github.com/NullVoxPopuli/kolay)'s `PageNav`, which generates the
+nav from the docs' folder structure). Rendering a second `<nav>` around that
+would create a nested navigation landmark, so the `<:nav>` block renders a
+plain styling container instead. Text (or a link) directly inside a top-level
+`<li>` gets the section-label treatment.
+
+```gjs live no-shadow
+import { NavigationList } from "nvp.ui";
+
+<template>
+  <NavigationList>
+    <:nav>
+      <nav aria-label="Demo: bring your own nav">
+        <ul>
+          <li>
+            Generated group
+            <ul>
+              <li><a href="#one" class="active">Page one</a></li>
+              <li><a href="#two">Page two</a></li>
+            </ul>
+          </li>
+        </ul>
+      </nav>
+    </:nav>
+  </NavigationList>
+
+  <style>
+    @scope {
+      .nvp__navigation-list {
+        max-width: 14rem;
+      }
+    }
+  </style>
+</template>
+```
+
+## Installation
+
+```bash
+pnpm add nvp.ui
+```
+
+## Anatomy
+
+```gjs
+import { NavigationList } from "nvp.ui/navigation-list";
+
+<template>
+  <NavigationList aria-label="Documentation" as |l|>
+    <l.Section @label="Group label" as |s|>
+      <s.Item><a href="/somewhere">Link goes here</a></s.Item>
+    </l.Section>
+  </NavigationList>
+</template>
+```
+
+`Section` groups links under an optional uppercase label; `Item` is the `<li>`
+wrapper for a single entry. The link element itself is always yours.
+
+## Accessibility
+
+- the component renders a real `<nav>` + `<ul>`/`<li>` structure, so assistive
+  technology announces it as a navigation landmark containing lists
+- pass an `aria-label` whenever a page has more than one `<nav>`
+- section labels are styled text, not headings, so they never break the page's
+  heading outline
+- prefer `aria-current="page"` on the current link -- the visual highlight and
+  the announced state then come from the same attribute
+- the `<:nav>` block exists so that content which already renders a `<nav>`
+  isn't wrapped in a second, nested navigation landmark
+
+## API Reference
+
+```gjs live no-shadow
+import { ComponentSignature } from "kolay";
+
+<template>
+  <ComponentSignature
+    @package="."
+    @module="declarations/components/navigation-list"
+    @name="Signature"
+  />
+</template>
+```
+
+### Section (yielded)
+
+```gjs live no-shadow
+import { ComponentSignature } from "kolay";
+
+<template>
+  <ComponentSignature
+    @package="."
+    @module="declarations/components/navigation-list"
+    @name="SectionSignature"
+  />
+</template>
+```
+
+### Item (yielded)
+
+```gjs live no-shadow
+import { ComponentSignature } from "kolay";
+
+<template>
+  <ComponentSignature
+    @package="."
+    @module="declarations/components/navigation-list"
+    @name="ItemSignature"
+  />
+</template>
+```
+
+### CSS Custom Properties
+
+|                Property                |                  Default                  | Description                           |
+| :------------------------------------: | :---------------------------------------: | :------------------------------------ |
+|    `--navigation-list-label-color`     |  `color-mix(… var(--color-text) 65% …)`   | Section label color                   |
+|     `--navigation-list-link-color`     |  `color-mix(… var(--color-text) 78% …)`   | Resting link color                    |
+|  `--navigation-list-hover-background`  |   `color-mix(… var(--color-text) 7% …)`   | Link hover background                 |
+| `--navigation-list-current-background` | `color-mix(… var(--color-primary) 24% …)` | Current-page link background          |
+|    `--navigation-list-section-gap`     |          `calc(6 * var(--gap))`           | Gap between sections                  |
+|     `--navigation-list-label-gap`      |              `var(--gap-2)`               | Gap between a label and its links     |
+|      `--navigation-list-item-gap`      |                   `0px`                   | Extra gap between links               |
+|    `--navigation-list-item-padding`    |       derived from `--padding-1/2`        | Link padding (makes the hover "chip") |
+|    `--navigation-list-item-radius`     |         `calc(2 * var(--radius))`         | Link corner radius                    |
+
+### CSS Classes
+
+|              Class               | Description                             |
+| :------------------------------: | :-------------------------------------- |
+|     `.nvp__navigation-list`      | The `<nav>` (or the `<:nav>` container) |
+| `.nvp__navigation-list__section` | One group of links                      |
+|  `.nvp__navigation-list__label`  | The uppercase section label             |
+|  `.nvp__navigation-list__item`   | The `<li>` around each link             |

--- a/public/docs/3-components/navigation-list.gjs.md
+++ b/public/docs/3-components/navigation-list.gjs.md
@@ -1,11 +1,13 @@
 # NavigationList
 
-A styled navigation list -- for sidebars, docs navs, tables of contents.
-It provides the list structure (spacing, uppercase section labels) and the link
-styling ("chip" hover + current-page highlight), while you bring your own links:
-plain `<a>`, `<LinkTo>`, and ember-primitives links all work.
+A navigation list is nothing more than a labelled `<ul>`: spaced link "chips"
+with hover + current-page styling, and an uppercase group label when `@label`
+is passed. You bring your own `<li>`s and links -- plain `<a>`, `<LinkTo>`, and
+ember-primitives links all work.
 
-This very docs site's sidebar is a `NavigationList`.
+Wrap one or more lists in [Navigation](/Docs/3-components/navigation) (or your
+own `<nav>`) to form a navigation landmark -- this very docs site's sidebar is
+`<Navigation>` + one `<NavigationList>` per group.
 
 ```gjs live no-shadow
 import { NavigationList } from "nvp.ui";
@@ -25,17 +27,15 @@ const Link = <template>
 </template>;
 
 <template>
-  <NavigationList aria-label="Demo: documentation" as |l|>
-    <l.Section @label="Get started">
-      <li><Link @href="#intro">Intro</Link></li>
-      <li><Link @href="#theme">Theme</Link></li>
-      <li><Link @href="#surfaces">Surfaces</Link></li>
-    </l.Section>
-    <l.Section @label="Components">
-      <li><Link @href="#button">Button</Link></li>
-      <li><Link @href="#menu">Menu</Link></li>
-      <li><Link @href="#timeline">Timeline</Link></li>
-    </l.Section>
+  <NavigationList @label="Get started">
+    <li><Link @href="#intro">Intro</Link></li>
+    <li><Link @href="#theme">Theme</Link></li>
+    <li><Link @href="#surfaces">Surfaces</Link></li>
+  </NavigationList>
+  <NavigationList @label="Components">
+    <li><Link @href="#button">Button</Link></li>
+    <li><Link @href="#menu">Menu</Link></li>
+    <li><Link @href="#timeline">Timeline</Link></li>
   </NavigationList>
 
   <style>
@@ -48,6 +48,9 @@ const Link = <template>
 </template>
 ```
 
+Consecutive lists space themselves apart, so several labelled lists stack into
+a grouped nav -- no wrapper elements involved.
+
 ## Marking the current page
 
 Give the current page's link an `aria-current` attribute -- that's both the
@@ -59,12 +62,10 @@ accessible way to convey "you are here" _and_ the styling hook. Links with an
 import { NavigationList } from "nvp.ui";
 
 <template>
-  <NavigationList aria-label="Demo: current page" as |l|>
-    <l.Section>
-      <li><a href="#overview">Overview</a></li>
-      <li><a href="#usage" aria-current="page">Usage</a></li>
-      <li><a href="#api">API</a></li>
-    </l.Section>
+  <NavigationList aria-label="Demo: current page">
+    <li><a href="#overview">Overview</a></li>
+    <li><a href="#usage" aria-current="page">Usage</a></li>
+    <li><a href="#api">API</a></li>
   </NavigationList>
 
   <style>
@@ -89,31 +90,28 @@ pnpm add nvp.ui
 import { NavigationList } from "nvp.ui/navigation-list";
 
 <template>
-  <NavigationList aria-label="Documentation" as |l|>
-    <l.Section @label="Group label">
-      <li><a href="/somewhere">Link goes here</a></li>
-    </l.Section>
+  <NavigationList @label="Group label">
+    <li><a href="/somewhere">Link goes here</a></li>
   </NavigationList>
 </template>
 ```
 
-`Section` renders one `<ul>` of links under an optional uppercase label. Its
-children are plain `<li>` elements that you render yourself -- the stylesheet
-targets the direct-descendant `li`s and the links inside them, so the link
-element is always yours.
+The component renders (at most) two sibling elements: the label `<span>` (only
+when `@label` is passed) and the `<ul>`. Splattributes land on the `<ul>` --
+the component _is_ the list.
 
 ## Accessibility
 
-- the component renders a real `<nav>` + `<ul>`/`<li>` structure, so assistive
-  technology announces it as a navigation landmark containing lists
-- pass an `aria-label` whenever a page has more than one `<nav>`
-- a section's `@label` is programmatically associated with its list via
+- `@label` is programmatically associated with the list via a unique id +
   `aria-labelledby`, so screen readers announce the list by its group name
   (e.g. "Get started, list, 3 items")
-- labels are styled text, not headings, so they never break the page's
+- the label is styled text, not a heading, so it never breaks the page's
   heading outline
 - prefer `aria-current="page"` on the current link -- the visual highlight and
   the announced state then come from the same attribute
+- a list is not a landmark: wrap lists in
+  [Navigation](/Docs/3-components/navigation) (or your own `<nav>`) so
+  assistive technology can jump to them
 
 ## API Reference
 
@@ -129,20 +127,6 @@ import { ComponentSignature } from "kolay";
 </template>
 ```
 
-### Section (yielded)
-
-```gjs live no-shadow
-import { ComponentSignature } from "kolay";
-
-<template>
-  <ComponentSignature
-    @package="."
-    @module="declarations/components/navigation-list"
-    @name="SectionSignature"
-  />
-</template>
-```
-
 ### CSS Custom Properties
 
 |                Property                |                  Default                  | Description                           |
@@ -151,8 +135,8 @@ import { ComponentSignature } from "kolay";
 |     `--navigation-list-link-color`     |  `color-mix(… var(--color-text) 78% …)`   | Resting link color                    |
 |  `--navigation-list-hover-background`  |   `color-mix(… var(--color-text) 7% …)`   | Link hover background                 |
 | `--navigation-list-current-background` | `color-mix(… var(--color-primary) 24% …)` | Current-page link background          |
-|    `--navigation-list-section-gap`     |          `calc(12 * var(--gap))`          | Gap between sections                  |
-|     `--navigation-list-label-gap`      |              `var(--gap-4)`               | Gap between a label and its links     |
+|    `--navigation-list-section-gap`     |          `calc(12 * var(--gap))`          | Gap between consecutive lists         |
+|     `--navigation-list-label-gap`      |              `var(--gap-4)`               | Gap between a label and its list      |
 |      `--navigation-list-item-gap`      |         `calc(2.5 * var(--gap))`          | Gap between links                     |
 |       `--navigation-list-indent`       |              `var(--gap-2)`               | List indentation under the label      |
 |    `--navigation-list-item-padding`    |       derived from `--padding-1/2`        | Link padding (makes the hover "chip") |
@@ -160,8 +144,7 @@ import { ComponentSignature } from "kolay";
 
 ### CSS Classes
 
-|              Class               | Description                   |
-| :------------------------------: | :---------------------------- |
-|     `.nvp__navigation-list`      | The `<nav>`                   |
-| `.nvp__navigation-list__section` | One group of links (a `<ul>`) |
-|  `.nvp__navigation-list__label`  | The uppercase section label   |
+|             Class              | Description                 |
+| :----------------------------: | :-------------------------- |
+|    `.nvp__navigation-list`     | The `<ul>`                  |
+| `.nvp__navigation-list__label` | The uppercase section label |

--- a/public/docs/3-components/navigation.gjs.md
+++ b/public/docs/3-components/navigation.gjs.md
@@ -1,0 +1,106 @@
+# Navigation
+
+The navigation landmark: a `<nav>` that owns its own layout and responsiveness,
+independent of what renders it. Its content is typically one or more
+[NavigationList](/Docs/3-components/navigation-list)s -- this very docs site's
+sidebar (and its mobile tray) is a `<Navigation>` built from kolay's docs
+manifest, with kolay providing only data.
+
+```gjs live no-shadow
+import { Navigation, NavigationList } from "nvp.ui";
+
+<template>
+  <Navigation aria-label="Demo: documentation">
+    <NavigationList @label="Get started">
+      <li><a href="#intro" aria-current="page">Intro</a></li>
+      <li><a href="#theme">Theme</a></li>
+    </NavigationList>
+    <NavigationList @label="Components">
+      <li><a href="#button">Button</a></li>
+      <li><a href="#menu">Menu</a></li>
+    </NavigationList>
+  </Navigation>
+
+  <style>
+    @scope {
+      .nvp__navigation {
+        max-width: 16rem;
+        border: var(--border-width) var(--border-style) var(--border-color);
+        border-radius: calc(2 * var(--radius));
+      }
+    }
+  </style>
+</template>
+```
+
+## Responsiveness
+
+`<Navigation>` is sticky and scrolls its own overflow, so long navs never push
+the page around:
+
+- it sticks `--navigation-top` below the viewport top (default `0px`), and
+  caps its height at the remaining viewport
+- inside a size container (like `<ApplicationShell>`), it keeps
+  `--navigation-min-width` (default `14rem`) on wide containers, and tightens
+  its padding on narrow ones (like the shell's mobile tray)
+
+## Working with ApplicationShell
+
+The [ApplicationShell](/Docs/3-components/application-shell) decides _where_
+navigation appears: the sidebar column on wide viewports, the mobile tray +
+hamburger on narrow ones. It also sets `--navigation-top` to its sticky
+header's height, so a `<Navigation>` placed in the `<:nav>` block sticks just
+below the header.
+
+`<Navigation>` owns everything about its own box -- stickiness, overflow,
+padding, width -- and the shell does not style the nav's contents at all.
+
+```gjs
+<ApplicationShell>
+  <:nav>
+    <Navigation aria-label="Documentation">
+      <NavigationList @label="Get started">
+        ...
+      </NavigationList>
+    </Navigation>
+  </:nav>
+  ...
+</ApplicationShell>
+```
+
+## Installation
+
+```bash
+pnpm add nvp.ui
+```
+
+## Accessibility
+
+- renders a real `<nav>`, so assistive technology announces it as a
+  navigation landmark
+- pass an `aria-label` whenever a page has more than one `<nav>`
+
+## API Reference
+
+```gjs live no-shadow
+import { ComponentSignature } from "kolay";
+
+<template>
+  <ComponentSignature @package="." @module="declarations/components/navigation" @name="Signature" />
+</template>
+```
+
+### CSS Custom Properties
+
+|           Property            |                Default                | Description                                            |
+| :---------------------------: | :-----------------------------------: | :----------------------------------------------------- |
+|      `--navigation-top`       |                 `0px`                 | Sticky offset from the viewport top (set by the shell) |
+|    `--navigation-padding`     | `1.5rem 1rem 2rem 1.25rem` (via gaps) | Padding on wide containers                             |
+| `--navigation-padding-narrow` |     `1.25rem 0.75rem` (via gaps)      | Padding on narrow containers (e.g. the mobile tray)    |
+|   `--navigation-min-width`    |                `14rem`                | Minimum width on wide containers                       |
+
+### CSS Classes
+
+|       Class        | Description |
+| :----------------: | :---------- |
+| `.nvp__navigation` | The `<nav>` |

--- a/src/components/application-shell.css
+++ b/src/components/application-shell.css
@@ -22,7 +22,8 @@
   overflow-x: hidden;
 }
 
-.mobile-menu__tray nav ul {
+/* (NavigationList owns the styling of its own lists) */
+.mobile-menu__tray nav ul:not(.nvp__navigation-list *) {
   padding-left: 0.5rem;
   list-style: none;
   line-height: 1.75rem;
@@ -121,7 +122,8 @@ header button.mobile-menu__toggle:active {
   }
 }
 
-.nvp__application-shell__layout nav ul {
+/* (NavigationList owns the styling of its own lists) */
+.nvp__application-shell__layout nav ul:not(.nvp__navigation-list *) {
   padding-left: 0.5rem;
   list-style: none;
   line-height: 1.75rem;

--- a/src/components/application-shell.css
+++ b/src/components/application-shell.css
@@ -22,13 +22,6 @@
   overflow-x: hidden;
 }
 
-/* (NavigationList owns the styling of its own lists) */
-.mobile-menu__tray nav ul:not(.nvp__navigation-list *) {
-  padding-left: 0.5rem;
-  list-style: none;
-  line-height: 1.75rem;
-}
-
 /* ── Animated hamburger icon ─────────────── */
 /* Animation is driven by --menu-progress (0 = closed, 1 = open)
    which tracks the menu's relative position for smooth, drag-aware
@@ -122,11 +115,13 @@ header button.mobile-menu__toggle:active {
   }
 }
 
-/* (NavigationList owns the styling of its own lists) */
-.nvp__application-shell__layout nav ul:not(.nvp__navigation-list *) {
-  padding-left: 0.5rem;
-  list-style: none;
-  line-height: 1.75rem;
+/*
+ * Navigation ↔ shell contract: the shell knows its sticky header's
+ * height, so it tells <Navigation> how far below the viewport top to
+ * stick. The nav's contents are entirely the nav components' business.
+ */
+.nvp__application-shell__layout {
+  --navigation-top: 3.5rem;
 }
 
 @container (max-width: 768px) {

--- a/src/components/navigation-list.css
+++ b/src/components/navigation-list.css
@@ -1,0 +1,109 @@
+/* ───────────────────────────────────────────
+   Navigation list — sidebar / docs-style nav
+   ─────────────────────────────────────────── */
+
+.nvp__navigation-list {
+  /*
+   * These are (re)computed here — not on :root — because color-mix()
+   * resolves var() references at the element the property is defined
+   * on, and the theme classes may be anywhere above (or below!) :root
+   * scope (e.g. nested theme demos).
+   */
+  --navigation-list-label-color: color-mix(in oklab, var(--color-text) 65%, transparent);
+  --navigation-list-link-color: color-mix(in oklab, var(--color-text) 78%, transparent);
+  --navigation-list-hover-background: color-mix(in oklab, var(--color-text) 7%, transparent);
+  --navigation-list-current-background: color-mix(in oklab, var(--color-primary) 24%, transparent);
+
+  --navigation-list-section-gap: calc(6 * var(--gap));
+  --navigation-list-label-gap: var(--gap-2);
+  --navigation-list-item-gap: 0px;
+  --navigation-list-item-padding: calc(1.25 * var(--padding-1)) calc(1.25 * var(--padding-2));
+  --navigation-list-item-radius: calc(2 * var(--radius));
+
+  line-height: 1.5;
+}
+
+/*
+ * Structural selectors (rather than only classes) so that navs the
+ * consumer brings along (via the <:nav> block) are styled the same
+ * as the composed Section / Item pieces.
+ */
+.nvp__navigation-list :where(ul) {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.9375rem;
+}
+
+/* ── Group spacing ────────────────────────── */
+
+nav.nvp__navigation-list,
+.nvp__navigation-list :where(nav > ul) {
+  display: grid;
+  gap: var(--navigation-list-section-gap);
+}
+
+.nvp__navigation-list :where(.nvp__navigation-list__section > ul, nav > ul > li > ul) {
+  display: grid;
+  gap: var(--navigation-list-item-gap);
+}
+
+/* ── Section labels ───────────────────────── */
+
+/*
+ * In brought-along navs, group labels are rendered as text (or an
+ * index link) directly inside the top-level list items…
+ */
+.nvp__navigation-list__label,
+.nvp__navigation-list :where(nav > ul > li) {
+  margin: 0;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--navigation-list-label-color);
+}
+
+/* …while the links within a group reset back to normal text */
+.nvp__navigation-list :where(nav > ul > li > ul) {
+  margin-top: var(--navigation-list-label-gap);
+  font-weight: 400;
+  letter-spacing: normal;
+  text-transform: none;
+  color: var(--color-text);
+}
+
+.nvp__navigation-list :where(.nvp__navigation-list__label + ul) {
+  margin-top: var(--navigation-list-label-gap);
+}
+
+/* ── Links ────────────────────────────────── */
+
+.nvp__navigation-list :where(a) {
+  display: block;
+  padding: var(--navigation-list-item-padding);
+  border-radius: var(--navigation-list-item-radius);
+  color: var(--navigation-list-link-color);
+  text-decoration: none;
+  transition:
+    background-color var(--fade-duration),
+    color var(--fade-duration);
+}
+
+.nvp__navigation-list :where(a):hover {
+  background: var(--navigation-list-hover-background);
+  color: var(--color-text);
+}
+
+/*
+ * The current page's link.
+ *
+ * `aria-current` is the accessible way to mark it; the `.active`
+ * class is honored too, for routers/link components that set one
+ * (ember's <LinkTo>, kolay's PageNav, …).
+ */
+.nvp__navigation-list :where(a):is(.active, [aria-current]:not([aria-current="false"])) {
+  background: var(--navigation-list-current-background);
+  color: var(--color-text);
+  font-weight: 500;
+}

--- a/src/components/navigation-list.css
+++ b/src/components/navigation-list.css
@@ -14,48 +14,35 @@
   --navigation-list-hover-background: color-mix(in oklab, var(--color-text) 7%, transparent);
   --navigation-list-current-background: color-mix(in oklab, var(--color-primary) 24%, transparent);
 
-  --navigation-list-section-gap: calc(6 * var(--gap));
-  --navigation-list-label-gap: var(--gap-2);
-  --navigation-list-item-gap: 0px;
+  --navigation-list-section-gap: calc(12 * var(--gap));
+  --navigation-list-label-gap: var(--gap-4);
+  --navigation-list-item-gap: calc(2.5 * var(--gap));
+  --navigation-list-indent: var(--gap-2);
   --navigation-list-item-padding: calc(1.25 * var(--padding-1)) calc(1.25 * var(--padding-2));
   --navigation-list-item-radius: calc(2 * var(--radius));
 
-  line-height: 1.5;
+  line-height: 1.65;
 }
 
-/*
- * Structural selectors (rather than only classes) so that navs the
- * consumer brings along (via the <:nav> block) are styled the same
- * as the composed Section / Item pieces.
- */
+/* ── Lists ────────────────────────────────── */
+
 .nvp__navigation-list :where(ul) {
+  display: grid;
+  gap: var(--navigation-list-item-gap);
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 var(--navigation-list-indent);
   list-style: none;
   font-size: 0.9375rem;
 }
 
-/* ── Group spacing ────────────────────────── */
-
-nav.nvp__navigation-list,
-.nvp__navigation-list :where(nav > ul) {
-  display: grid;
-  gap: var(--navigation-list-section-gap);
-}
-
-.nvp__navigation-list :where(.nvp__navigation-list__section > ul, nav > ul > li > ul) {
-  display: grid;
-  gap: var(--navigation-list-item-gap);
+.nvp__navigation-list :where(ul > li) {
+  margin: 0;
 }
 
 /* ── Section labels ───────────────────────── */
 
-/*
- * In brought-along navs, group labels are rendered as text (or an
- * index link) directly inside the top-level list items…
- */
-.nvp__navigation-list__label,
-.nvp__navigation-list :where(nav > ul > li) {
+.nvp__navigation-list__label {
+  display: block;
   margin: 0;
   font-size: 0.6875rem;
   font-weight: 700;
@@ -64,22 +51,20 @@ nav.nvp__navigation-list,
   color: var(--navigation-list-label-color);
 }
 
-/* …while the links within a group reset back to normal text */
-.nvp__navigation-list :where(nav > ul > li > ul) {
-  margin-top: var(--navigation-list-label-gap);
-  font-weight: 400;
-  letter-spacing: normal;
-  text-transform: none;
-  color: var(--color-text);
-}
-
 .nvp__navigation-list :where(.nvp__navigation-list__label + ul) {
   margin-top: var(--navigation-list-label-gap);
 }
 
+/* ── Space between sections ───────────────── */
+
+.nvp__navigation-list > :where(* + .nvp__navigation-list__label),
+.nvp__navigation-list > :where(ul + ul) {
+  margin-top: var(--navigation-list-section-gap);
+}
+
 /* ── Links ────────────────────────────────── */
 
-.nvp__navigation-list :where(a) {
+.nvp__navigation-list :where(li > a) {
   display: block;
   padding: var(--navigation-list-item-padding);
   border-radius: var(--navigation-list-item-radius);
@@ -90,7 +75,7 @@ nav.nvp__navigation-list,
     color var(--fade-duration);
 }
 
-.nvp__navigation-list :where(a):hover {
+.nvp__navigation-list :where(li > a):hover {
   background: var(--navigation-list-hover-background);
   color: var(--color-text);
 }
@@ -100,9 +85,9 @@ nav.nvp__navigation-list,
  *
  * `aria-current` is the accessible way to mark it; the `.active`
  * class is honored too, for routers/link components that set one
- * (ember's <LinkTo>, kolay's PageNav, …).
+ * (ember's <LinkTo>, …).
  */
-.nvp__navigation-list :where(a):is(.active, [aria-current]:not([aria-current="false"])) {
+.nvp__navigation-list :where(li > a):is(.active, [aria-current]:not([aria-current="false"])) {
   background: var(--navigation-list-current-background);
   color: var(--color-text);
   font-weight: 500;

--- a/src/components/navigation-list.css
+++ b/src/components/navigation-list.css
@@ -1,73 +1,70 @@
 /* ───────────────────────────────────────────
-   Navigation list — sidebar / docs-style nav
+   Navigation list — a labelled <ul> of links
    ─────────────────────────────────────────── */
 
-.nvp__navigation-list {
-  /*
-   * These are (re)computed here — not on :root — because color-mix()
-   * resolves var() references at the element the property is defined
-   * on, and the theme classes may be anywhere above (or below!) :root
-   * scope (e.g. nested theme demos).
-   */
+/*
+ * The color-mixes are (re)computed here — not on :root — because
+ * color-mix() resolves var() references at the element the property
+ * is defined on, and the theme classes may be anywhere above (or
+ * below!) :root scope (e.g. nested theme demos).
+ *
+ * (The label is a sibling of the <ul>, not a child, so both need them.)
+ */
+:is(.nvp__navigation-list, .nvp__navigation-list__label) {
   --navigation-list-label-color: color-mix(in oklab, var(--color-text) 65%, transparent);
   --navigation-list-link-color: color-mix(in oklab, var(--color-text) 78%, transparent);
   --navigation-list-hover-background: color-mix(in oklab, var(--color-text) 7%, transparent);
   --navigation-list-current-background: color-mix(in oklab, var(--color-primary) 24%, transparent);
+}
 
-  --navigation-list-section-gap: calc(12 * var(--gap));
-  --navigation-list-label-gap: var(--gap-4);
-  --navigation-list-item-gap: calc(2.5 * var(--gap));
-  --navigation-list-indent: var(--gap-2);
-  --navigation-list-item-padding: calc(1.25 * var(--padding-1)) calc(1.25 * var(--padding-2));
-  --navigation-list-item-radius: calc(2 * var(--radius));
+/* ── The list ─────────────────────────────── */
 
+.nvp__navigation-list {
+  display: grid;
+  gap: var(--navigation-list-item-gap, calc(2.5 * var(--gap)));
+  margin: 0;
+  padding: 0 0 0 var(--navigation-list-indent, var(--gap-2));
+  list-style: none;
+  font-size: 0.9375rem;
   line-height: 1.65;
 }
 
-/* ── Lists ────────────────────────────────── */
-
-.nvp__navigation-list :where(ul) {
-  display: grid;
-  gap: var(--navigation-list-item-gap);
-  margin: 0;
-  padding: 0 0 0 var(--navigation-list-indent);
-  list-style: none;
-  font-size: 0.9375rem;
-}
-
-.nvp__navigation-list :where(ul > li) {
+.nvp__navigation-list > :where(li) {
   margin: 0;
 }
 
-/* ── Section labels ───────────────────────── */
+/* ── The label ────────────────────────────── */
 
 .nvp__navigation-list__label {
   display: block;
   margin: 0;
   font-size: 0.6875rem;
   font-weight: 700;
+  line-height: 1.65;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--navigation-list-label-color);
 }
 
-.nvp__navigation-list :where(.nvp__navigation-list__label + ul) {
-  margin-top: var(--navigation-list-label-gap);
+.nvp__navigation-list__label + .nvp__navigation-list {
+  margin-top: var(--navigation-list-label-gap, var(--gap-4));
 }
 
-/* ── Space between sections ───────────────── */
-
-.nvp__navigation-list > :where(* + .nvp__navigation-list__label),
-.nvp__navigation-list > :where(ul + ul) {
-  margin-top: var(--navigation-list-section-gap);
+/* Consecutive lists space themselves apart into sections */
+.nvp__navigation-list + .nvp__navigation-list__label,
+.nvp__navigation-list + .nvp__navigation-list {
+  margin-top: var(--navigation-list-section-gap, calc(12 * var(--gap)));
 }
 
 /* ── Links ────────────────────────────────── */
 
 .nvp__navigation-list :where(li > a) {
   display: block;
-  padding: var(--navigation-list-item-padding);
-  border-radius: var(--navigation-list-item-radius);
+  padding: var(
+    --navigation-list-item-padding,
+    calc(1.25 * var(--padding-1)) calc(1.25 * var(--padding-2))
+  );
+  border-radius: var(--navigation-list-item-radius, calc(2 * var(--radius)));
   color: var(--navigation-list-link-color);
   text-decoration: none;
   transition:

--- a/src/components/navigation-list.gts
+++ b/src/components/navigation-list.gts
@@ -1,0 +1,154 @@
+import "./variables.css";
+import "./focus.css";
+import "./navigation-list.css";
+
+import { hash } from "@ember/helper";
+
+import type { TOC } from "@ember/component/template-only";
+
+export interface ItemSignature {
+  /**
+   * The `<li>` wrapper for a single navigation entry.
+   *
+   * Render any link element inside — a plain `<a>`, `<LinkTo>`,
+   * an ember-primitives link, etc. The link is styled via CSS,
+   * and the current page is highlighted when the link has an
+   * `aria-current` attribute or an `active` class.
+   */
+  Element: HTMLLIElement;
+  Blocks: {
+    /**
+     * The link (or other content) for this entry.
+     */
+    default: [];
+  };
+}
+
+const Item: TOC<ItemSignature> = <template>
+  <li class="nvp__navigation-list__item" ...attributes>
+    {{yield}}
+  </li>
+</template>;
+
+export interface SectionSignature {
+  /**
+   * The wrapper around one group of links.
+   */
+  Element: HTMLDivElement;
+  Args: {
+    /**
+     * Optional group heading, rendered in an uppercase
+     * "section label" treatment above the links.
+     *
+     * Omit for a plain (unlabelled) list of links.
+     */
+    label?: string;
+  };
+  Blocks: {
+    /**
+     * One or more `<Item>`s.
+     */
+    default: [section: { Item: TOC<ItemSignature> }];
+  };
+}
+
+const Section: TOC<SectionSignature> = <template>
+  <div class="nvp__navigation-list__section" ...attributes>
+    {{#if @label}}
+      <p class="nvp__navigation-list__label">{{@label}}</p>
+    {{/if}}
+    <ul>
+      {{yield (hash Item=Item)}}
+    </ul>
+  </div>
+</template>;
+
+/**
+ * Two usage modes:
+ *
+ * **Composed:** the default block yields `Section` (which yields `Item`) —
+ * the component renders the `<nav>` for you.
+ *
+ * **Bring your own nav:** the `<:nav>` block renders a plain styling
+ * container instead, for content that already renders its own `<nav>`
+ * (e.g. kolay's `PageNav`, or a hand-written `<nav><ul>…`).
+ */
+export type Signature =
+  | {
+      /**
+       * The `<nav>` element.
+       *
+       * When there are multiple `<nav>` elements on a page,
+       * pass an `aria-label` to distinguish them.
+       */
+      Element: HTMLElement;
+      Blocks: {
+        /**
+         * Yields `Section` for composing groups of links.
+         */
+        default: [list: { Section: TOC<SectionSignature> }];
+        nav: never;
+      };
+    }
+  | {
+      /**
+       * The styling container (a `<div>`) around your own `<nav>`.
+       */
+      Element: HTMLDivElement;
+      Blocks: {
+        /**
+         * Content that renders its own `<nav>` + `<ul>` structure.
+         *
+         * Nested lists are styled like sections: text (or a link)
+         * directly inside a top-level `<li>` gets the section-label
+         * treatment, and links get the same hover / current styling
+         * as composed `Item`s.
+         */
+        nav: [];
+        default: never;
+      };
+    };
+
+/**
+ * A styled container for navigation lists (sidebars, docs navs, …):
+ * plain lists, spaced groups with uppercase section labels, and
+ * "chip" hover / current-page styling for the links.
+ *
+ * Bring your own links — plain `<a>`, `<LinkTo>`, ember-primitives
+ * links, and generated navs all work. The current page is highlighted
+ * via `[aria-current]` (or an `active` class, for routers that set one).
+ *
+ * @example Composed
+ * ```gts
+ * import { NavigationList } from "nvp.ui/navigation-list";
+ *
+ * <template>
+ *   <NavigationList aria-label="Documentation" as |l|>
+ *     <l.Section @label="Get started" as |s|>
+ *       <s.Item><a href="/intro" aria-current="page">Intro</a></s.Item>
+ *       <s.Item><a href="/install">Installation</a></s.Item>
+ *     </l.Section>
+ *   </NavigationList>
+ * </template>
+ * ```
+ *
+ * @example Bring your own nav
+ * ```gts
+ * <NavigationList>
+ *   <:nav>
+ *     <PageNav aria-label="Documentation" />
+ *   </:nav>
+ * </NavigationList>
+ * ```
+ */
+export const NavigationList: TOC<Signature> = <template>
+  {{#if (has-block "nav")}}
+    <div class="nvp__navigation-list" ...attributes>
+      {{yield to="nav"}}
+    </div>
+  {{else}}
+    <nav class="nvp__navigation-list" ...attributes>
+      {{yield (hash Section=Section)}}
+    </nav>
+  {{/if}}
+</template>;

--- a/src/components/navigation-list.gts
+++ b/src/components/navigation-list.gts
@@ -2,15 +2,15 @@ import "./variables.css";
 import "./focus.css";
 import "./navigation-list.css";
 
-import { hash, uniqueId } from "@ember/helper";
+import { uniqueId } from "@ember/helper";
 
 import type { TOC } from "@ember/component/template-only";
 
-export interface SectionSignature {
+export interface Signature {
   /**
-   * The `<ul>` for one group of links.
+   * The `<ul>` -- the component *is* the list.
    *
-   * Its children are plain `<li>` elements that you render yourself --
+   * Its children are plain `<li>` elements that you render yourself:
    * the stylesheet targets the direct-descendant `li`s and the links
    * inside them. Any link element works: a plain `<a>`, `<LinkTo>`,
    * an ember-primitives link, etc. The current page is highlighted
@@ -40,58 +40,36 @@ export interface SectionSignature {
   };
 }
 
-const Section: TOC<SectionSignature> = <template>
-  {{#let (uniqueId) as |labelId|}}
-    {{#if @label}}
-      <span class="nvp__navigation-list__label" id={{labelId}}>{{@label}}</span>
-    {{/if}}
-    <ul class="nvp__navigation-list__section" aria-labelledby={{if @label labelId}} ...attributes>
-      {{yield}}
-    </ul>
-  {{/let}}
-</template>;
-
-export interface Signature {
-  /**
-   * The `<nav>` element.
-   *
-   * When there are multiple `<nav>` elements on a page,
-   * pass an `aria-label` to distinguish them.
-   */
-  Element: HTMLElement;
-  Blocks: {
-    /**
-     * Yields `Section` for composing groups of links.
-     */
-    default: [list: { Section: TOC<SectionSignature> }];
-  };
-}
-
 /**
- * A styled navigation list (sidebars, docs navs, …): spaced groups
- * with uppercase section labels, and "chip" hover / current-page
- * styling for the links.
+ * A navigation list is nothing more than a (optionally labelled) `<ul>`:
+ * spaced link "chips" with hover / current-page styling, and an
+ * uppercase group label when `@label` is passed.
  *
- * Bring your own links -- plain `<a>`, `<LinkTo>`, ember-primitives
- * links all work. The current page is highlighted via `[aria-current]`
- * (or an `active` class, for routers that set one).
+ * There is no wrapper element -- the label `<span>` (when present) and
+ * the `<ul>` are rendered as siblings. Consecutive `<NavigationList>`s
+ * space themselves apart, so several labelled lists stack into a
+ * grouped nav. Wrap them in `<Navigation>` (or your own `<nav>`) to
+ * form a navigation landmark.
  *
  * @example
  * ```gts
  * import { NavigationList } from "nvp.ui/navigation-list";
  *
  * <template>
- *   <NavigationList aria-label="Documentation" as |l|>
- *     <l.Section @label="Get started">
- *       <li><a href="/intro" aria-current="page">Intro</a></li>
- *       <li><a href="/install">Installation</a></li>
- *     </l.Section>
+ *   <NavigationList @label="Get started">
+ *     <li><a href="/intro" aria-current="page">Intro</a></li>
+ *     <li><a href="/install">Installation</a></li>
  *   </NavigationList>
  * </template>
  * ```
  */
 export const NavigationList: TOC<Signature> = <template>
-  <nav class="nvp__navigation-list" ...attributes>
-    {{yield (hash Section=Section)}}
-  </nav>
+  {{#let (uniqueId) as |labelId|}}
+    {{#if @label}}
+      <span class="nvp__navigation-list__label" id={{labelId}}>{{@label}}</span>
+    {{/if}}
+    <ul class="nvp__navigation-list" aria-labelledby={{if @label labelId}} ...attributes>
+      {{yield}}
+    </ul>
+  {{/let}}
 </template>;

--- a/src/components/navigation-list.gts
+++ b/src/components/navigation-list.gts
@@ -2,43 +2,31 @@ import "./variables.css";
 import "./focus.css";
 import "./navigation-list.css";
 
-import { hash } from "@ember/helper";
+import { hash, uniqueId } from "@ember/helper";
 
 import type { TOC } from "@ember/component/template-only";
 
-export interface ItemSignature {
-  /**
-   * The `<li>` wrapper for a single navigation entry.
-   *
-   * Render any link element inside — a plain `<a>`, `<LinkTo>`,
-   * an ember-primitives link, etc. The link is styled via CSS,
-   * and the current page is highlighted when the link has an
-   * `aria-current` attribute or an `active` class.
-   */
-  Element: HTMLLIElement;
-  Blocks: {
-    /**
-     * The link (or other content) for this entry.
-     */
-    default: [];
-  };
-}
-
-const Item: TOC<ItemSignature> = <template>
-  <li class="nvp__navigation-list__item" ...attributes>
-    {{yield}}
-  </li>
-</template>;
-
 export interface SectionSignature {
   /**
-   * The wrapper around one group of links.
+   * The `<ul>` for one group of links.
+   *
+   * Its children are plain `<li>` elements that you render yourself --
+   * the stylesheet targets the direct-descendant `li`s and the links
+   * inside them. Any link element works: a plain `<a>`, `<LinkTo>`,
+   * an ember-primitives link, etc. The current page is highlighted
+   * when its link has an `aria-current` attribute (or an `active`
+   * class, for routers that set one).
    */
-  Element: HTMLDivElement;
+  Element: HTMLUListElement;
   Args: {
     /**
-     * Optional group heading, rendered in an uppercase
-     * "section label" treatment above the links.
+     * Optional group heading, rendered in an uppercase "section label"
+     * treatment above the list.
+     *
+     * The label is programmatically associated with the list via
+     * `aria-labelledby`, so screen readers announce the list by name.
+     * It is styled text, not a heading, so it never affects the page's
+     * heading outline.
      *
      * Omit for a plain (unlabelled) list of links.
      */
@@ -46,109 +34,64 @@ export interface SectionSignature {
   };
   Blocks: {
     /**
-     * One or more `<Item>`s.
+     * One or more `<li>`s, each containing a link.
      */
-    default: [section: { Item: TOC<ItemSignature> }];
+    default: [];
   };
 }
 
 const Section: TOC<SectionSignature> = <template>
-  <div class="nvp__navigation-list__section" ...attributes>
+  {{#let (uniqueId) as |labelId|}}
     {{#if @label}}
-      <p class="nvp__navigation-list__label">{{@label}}</p>
+      <span class="nvp__navigation-list__label" id={{labelId}}>{{@label}}</span>
     {{/if}}
-    <ul>
-      {{yield (hash Item=Item)}}
+    <ul class="nvp__navigation-list__section" aria-labelledby={{if @label labelId}} ...attributes>
+      {{yield}}
     </ul>
-  </div>
+  {{/let}}
 </template>;
 
-/**
- * Two usage modes:
- *
- * **Composed:** the default block yields `Section` (which yields `Item`) —
- * the component renders the `<nav>` for you.
- *
- * **Bring your own nav:** the `<:nav>` block renders a plain styling
- * container instead, for content that already renders its own `<nav>`
- * (e.g. kolay's `PageNav`, or a hand-written `<nav><ul>…`).
- */
-export type Signature =
-  | {
-      /**
-       * The `<nav>` element.
-       *
-       * When there are multiple `<nav>` elements on a page,
-       * pass an `aria-label` to distinguish them.
-       */
-      Element: HTMLElement;
-      Blocks: {
-        /**
-         * Yields `Section` for composing groups of links.
-         */
-        default: [list: { Section: TOC<SectionSignature> }];
-        nav: never;
-      };
-    }
-  | {
-      /**
-       * The styling container (a `<div>`) around your own `<nav>`.
-       */
-      Element: HTMLDivElement;
-      Blocks: {
-        /**
-         * Content that renders its own `<nav>` + `<ul>` structure.
-         *
-         * Nested lists are styled like sections: text (or a link)
-         * directly inside a top-level `<li>` gets the section-label
-         * treatment, and links get the same hover / current styling
-         * as composed `Item`s.
-         */
-        nav: [];
-        default: never;
-      };
-    };
+export interface Signature {
+  /**
+   * The `<nav>` element.
+   *
+   * When there are multiple `<nav>` elements on a page,
+   * pass an `aria-label` to distinguish them.
+   */
+  Element: HTMLElement;
+  Blocks: {
+    /**
+     * Yields `Section` for composing groups of links.
+     */
+    default: [list: { Section: TOC<SectionSignature> }];
+  };
+}
 
 /**
- * A styled container for navigation lists (sidebars, docs navs, …):
- * plain lists, spaced groups with uppercase section labels, and
- * "chip" hover / current-page styling for the links.
+ * A styled navigation list (sidebars, docs navs, …): spaced groups
+ * with uppercase section labels, and "chip" hover / current-page
+ * styling for the links.
  *
- * Bring your own links — plain `<a>`, `<LinkTo>`, ember-primitives
- * links, and generated navs all work. The current page is highlighted
- * via `[aria-current]` (or an `active` class, for routers that set one).
+ * Bring your own links -- plain `<a>`, `<LinkTo>`, ember-primitives
+ * links all work. The current page is highlighted via `[aria-current]`
+ * (or an `active` class, for routers that set one).
  *
- * @example Composed
+ * @example
  * ```gts
  * import { NavigationList } from "nvp.ui/navigation-list";
  *
  * <template>
  *   <NavigationList aria-label="Documentation" as |l|>
- *     <l.Section @label="Get started" as |s|>
- *       <s.Item><a href="/intro" aria-current="page">Intro</a></s.Item>
- *       <s.Item><a href="/install">Installation</a></s.Item>
+ *     <l.Section @label="Get started">
+ *       <li><a href="/intro" aria-current="page">Intro</a></li>
+ *       <li><a href="/install">Installation</a></li>
  *     </l.Section>
  *   </NavigationList>
  * </template>
  * ```
- *
- * @example Bring your own nav
- * ```gts
- * <NavigationList>
- *   <:nav>
- *     <PageNav aria-label="Documentation" />
- *   </:nav>
- * </NavigationList>
- * ```
  */
 export const NavigationList: TOC<Signature> = <template>
-  {{#if (has-block "nav")}}
-    <div class="nvp__navigation-list" ...attributes>
-      {{yield to="nav"}}
-    </div>
-  {{else}}
-    <nav class="nvp__navigation-list" ...attributes>
-      {{yield (hash Section=Section)}}
-    </nav>
-  {{/if}}
+  <nav class="nvp__navigation-list" ...attributes>
+    {{yield (hash Section=Section)}}
+  </nav>
 </template>;

--- a/src/components/navigation.css
+++ b/src/components/navigation.css
@@ -1,0 +1,36 @@
+/* ───────────────────────────────────────────
+   Navigation — the <nav> landmark's own layout
+   ─────────────────────────────────────────── */
+
+/*
+ * Contract: an ancestor (e.g. ApplicationShell's layout, which knows
+ * its sticky header's height) may set `--navigation-top`; the nav
+ * sticks that far below the viewport top and scrolls its own overflow.
+ */
+.nvp__navigation {
+  position: sticky;
+  top: var(--navigation-top, 0px);
+  max-height: calc(100dvh - var(--navigation-top, 0px));
+  overflow-y: auto;
+  padding: var(
+    --navigation-padding,
+    calc(6 * var(--gap)) var(--gap-4) calc(8 * var(--gap)) calc(5 * var(--gap))
+  );
+}
+
+/*
+ * Responsiveness, relative to the nearest size container
+ * (ApplicationShell provides one).
+ */
+@container (min-width: 769px) {
+  .nvp__navigation {
+    min-width: var(--navigation-min-width, 14rem);
+  }
+}
+
+/* Narrow containers (e.g. the shell's mobile tray) get tighter padding */
+@container (max-width: 768px) {
+  .nvp__navigation {
+    padding: var(--navigation-padding-narrow, calc(5 * var(--gap)) var(--gap-3));
+  }
+}

--- a/src/components/navigation.gts
+++ b/src/components/navigation.gts
@@ -10,7 +10,7 @@ export interface Signature {
    * When there are multiple `<nav>` elements on a page,
    * pass an `aria-label` to distinguish them.
    */
-  Element: HTMLElement;
+  Element: HTMLElementTagNameMap["nav"];
   Blocks: {
     /**
      * The navigation's content -- typically one or more

--- a/src/components/navigation.gts
+++ b/src/components/navigation.gts
@@ -1,0 +1,59 @@
+import "./variables.css";
+import "./navigation.css";
+
+import type { TOC } from "@ember/component/template-only";
+
+export interface Signature {
+  /**
+   * The `<nav>` element.
+   *
+   * When there are multiple `<nav>` elements on a page,
+   * pass an `aria-label` to distinguish them.
+   */
+  Element: HTMLElement;
+  Blocks: {
+    /**
+     * The navigation's content -- typically one or more
+     * `<NavigationList>`s (with or without `@label`s).
+     */
+    default: [];
+  };
+}
+
+/**
+ * The navigation landmark: a `<nav>` that owns its own layout and
+ * responsiveness, independent of what renders it.
+ *
+ * - **Sticky + scroll**: sticks `--navigation-top` (default `0px`)
+ *   below the viewport top and scrolls its own overflow, so long
+ *   navs never push the page around.
+ * - **Responsive**: inside a size container (e.g. `<ApplicationShell>`),
+ *   it keeps a comfortable `min-width` on wide containers and tightens
+ *   its padding on narrow ones (like the shell's mobile tray).
+ *
+ * ### Contract with `<ApplicationShell>`
+ *
+ * The shell decides *where* navigation appears (the sidebar column on
+ * wide viewports, the mobile tray + hamburger on narrow ones) and sets
+ * `--navigation-top` to its sticky header's height. `<Navigation>`
+ * owns everything about its own box: stickiness, overflow, padding,
+ * and width. The shell does not style the nav's contents.
+ *
+ * @example
+ * ```gts
+ * import { Navigation, NavigationList } from "nvp.ui";
+ *
+ * <template>
+ *   <Navigation aria-label="Documentation">
+ *     <NavigationList @label="Get started">
+ *       <li><a href="/intro" aria-current="page">Intro</a></li>
+ *     </NavigationList>
+ *   </Navigation>
+ * </template>
+ * ```
+ */
+export const Navigation: TOC<Signature> = <template>
+  <nav class="nvp__navigation" ...attributes>
+    {{yield}}
+  </nav>
+</template>;

--- a/src/components/navigation.gts
+++ b/src/components/navigation.gts
@@ -10,7 +10,8 @@ export interface Signature {
    * When there are multiple `<nav>` elements on a page,
    * pass an `aria-label` to distinguish them.
    */
-  Element: HTMLElementTagNameMap["nav"];
+  // there is no HTMLNavigationElement — <nav> is a plain HTMLElement
+  Element: HTMLElement;
   Blocks: {
     /**
      * The navigation's content -- typically one or more

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { Button } from "./components/button.gts";
 export { ExternalLink } from "./components/external-link.gts";
 export { Header } from "./components/header.gts";
 export { Menu } from "./components/menu.gts";
+export { NavigationList } from "./components/navigation-list.gts";
 export { politeSticky } from "./components/polite-sticky.gts";
 export { Shell } from "./components/shell.gts";
 export { ThemeToggle } from "./components/theme-toggle.gts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { Button } from "./components/button.gts";
 export { ExternalLink } from "./components/external-link.gts";
 export { Header } from "./components/header.gts";
 export { Menu } from "./components/menu.gts";
+export { Navigation } from "./components/navigation.gts";
 export { NavigationList } from "./components/navigation-list.gts";
 export { politeSticky } from "./components/polite-sticky.gts";
 export { Shell } from "./components/shell.gts";

--- a/tests/components/navigation-list-test.gts
+++ b/tests/components/navigation-list-test.gts
@@ -1,0 +1,210 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+
+import { NavigationList } from "#src/index.ts";
+
+module("NavigationList", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders a nav element", async function (assert) {
+    await render(
+      <template>
+        <NavigationList as |l|>
+          <l.Section as |s|>
+            <s.Item><a href="/a">A</a></s.Item>
+          </l.Section>
+        </NavigationList>
+      </template>,
+    );
+
+    assert.dom("nav.nvp__navigation-list").exists();
+  });
+
+  test("splats attributes on the nav", async function (assert) {
+    await render(
+      <template>
+        <NavigationList aria-label="Documentation" data-test-nav as |l|>
+          <l.Section as |s|>
+            <s.Item><a href="/a">A</a></s.Item>
+          </l.Section>
+        </NavigationList>
+      </template>,
+    );
+
+    assert.dom("[data-test-nav]").hasTagName("nav");
+    assert.dom("[data-test-nav]").hasClass("nvp__navigation-list");
+    assert.dom("[data-test-nav]").hasAria("label", "Documentation");
+  });
+
+  module("Section", function () {
+    test("renders the label", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section @label="Components" as |s|>
+              <s.Item><a href="/button">Button</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list__label").hasText("Components");
+    });
+
+    test("omits the label element when no @label is given", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section as |s|>
+              <s.Item><a href="/button">Button</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list__label").doesNotExist();
+    });
+
+    test("splats attributes on the section", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section @label="Components" data-test-section as |s|>
+              <s.Item><a href="/button">Button</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom("[data-test-section]").hasClass("nvp__navigation-list__section");
+    });
+
+    test("supports multiple sections", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section @label="Get started" as |s|>
+              <s.Item><a href="/intro">Intro</a></s.Item>
+            </l.Section>
+            <l.Section @label="Components" as |s|>
+              <s.Item><a href="/button">Button</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list__section").exists({ count: 2 });
+      assert.dom(".nvp__navigation-list__label").exists({ count: 2 });
+    });
+  });
+
+  module("Item", function () {
+    test("items are list items within the section's list", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section as |s|>
+              <s.Item><a href="/a">A</a></s.Item>
+              <s.Item><a href="/b">B</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list__section > ul > li.nvp__navigation-list__item").exists({
+        count: 2,
+      });
+    });
+
+    test("works with plain <a> children", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section as |s|>
+              <s.Item><a href="/somewhere">Somewhere</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list__item > a[href='/somewhere']").hasText("Somewhere");
+    });
+
+    test("splats attributes on the item", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section as |s|>
+              <s.Item data-test-item><a href="/a">A</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom("[data-test-item]").hasTagName("li");
+      assert.dom("[data-test-item]").hasClass("nvp__navigation-list__item");
+    });
+  });
+
+  module("current page styling hooks", function () {
+    test("aria-current is preserved on consumer-rendered links", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section as |s|>
+              <s.Item><a href="/here" aria-current="page">Here</a></s.Item>
+              <s.Item><a href="/there">There</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list a[aria-current='page']").exists({ count: 1 });
+      assert.dom(".nvp__navigation-list a[aria-current='page']").hasText("Here");
+    });
+
+    test("active-class links (as routers render them) are addressable", async function (assert) {
+      await render(
+        <template>
+          <NavigationList as |l|>
+            <l.Section as |s|>
+              <s.Item><a href="/here" class="active">Here</a></s.Item>
+            </l.Section>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom(".nvp__navigation-list a.active").exists();
+    });
+  });
+
+  module("bring your own nav (<:nav>)", function () {
+    test("renders a styling container instead of a second <nav>", async function (assert) {
+      await render(
+        <template>
+          <NavigationList data-test-container>
+            <:nav>
+              <nav aria-label="Documentation">
+                <ul>
+                  <li>
+                    Group
+                    <ul>
+                      <li><a href="/a" class="active">A</a></li>
+                      <li><a href="/b">B</a></li>
+                    </ul>
+                  </li>
+                </ul>
+              </nav>
+            </:nav>
+          </NavigationList>
+        </template>,
+      );
+
+      assert.dom("[data-test-container]").hasTagName("div");
+      assert.dom("[data-test-container]").hasClass("nvp__navigation-list");
+      assert.dom("[data-test-container] nav").exists({ count: 1 });
+      assert.dom("[data-test-container] nav a").exists({ count: 2 });
+    });
+  });
+});

--- a/tests/components/navigation-list-test.gts
+++ b/tests/components/navigation-list-test.gts
@@ -11,8 +11,8 @@ module("NavigationList", function (hooks) {
     await render(
       <template>
         <NavigationList as |l|>
-          <l.Section as |s|>
-            <s.Item><a href="/a">A</a></s.Item>
+          <l.Section>
+            <li><a href="/a">A</a></li>
           </l.Section>
         </NavigationList>
       </template>,
@@ -25,8 +25,8 @@ module("NavigationList", function (hooks) {
     await render(
       <template>
         <NavigationList aria-label="Documentation" data-test-nav as |l|>
-          <l.Section as |s|>
-            <s.Item><a href="/a">A</a></s.Item>
+          <l.Section>
+            <li><a href="/a">A</a></li>
           </l.Section>
         </NavigationList>
       </template>,
@@ -38,57 +38,65 @@ module("NavigationList", function (hooks) {
   });
 
   module("Section", function () {
-    test("renders the label", async function (assert) {
+    test("renders the label, associated with the list via aria-labelledby", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section @label="Components" as |s|>
-              <s.Item><a href="/button">Button</a></s.Item>
+            <l.Section @label="Components">
+              <li><a href="/button">Button</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
       assert.dom(".nvp__navigation-list__label").hasText("Components");
+
+      const label = document.querySelector(".nvp__navigation-list__label");
+      const list = document.querySelector(".nvp__navigation-list__section");
+
+      assert.ok(label?.id, "the label has an id");
+      assert.dom(list).hasAria("labelledby", label?.id ?? "", "the list is labelled by the label");
     });
 
-    test("omits the label element when no @label is given", async function (assert) {
+    test("omits the label (and aria-labelledby) when no @label is given", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section as |s|>
-              <s.Item><a href="/button">Button</a></s.Item>
+            <l.Section>
+              <li><a href="/button">Button</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
       assert.dom(".nvp__navigation-list__label").doesNotExist();
+      assert.dom(".nvp__navigation-list__section").doesNotHaveAria("labelledby");
     });
 
-    test("splats attributes on the section", async function (assert) {
+    test("splats attributes on the section's list", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section @label="Components" data-test-section as |s|>
-              <s.Item><a href="/button">Button</a></s.Item>
+            <l.Section @label="Components" data-test-section>
+              <li><a href="/button">Button</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
+      assert.dom("[data-test-section]").hasTagName("ul");
       assert.dom("[data-test-section]").hasClass("nvp__navigation-list__section");
     });
 
-    test("supports multiple sections", async function (assert) {
+    test("supports multiple sections, each with their own label association", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section @label="Get started" as |s|>
-              <s.Item><a href="/intro">Intro</a></s.Item>
+            <l.Section @label="Get started">
+              <li><a href="/intro">Intro</a></li>
             </l.Section>
-            <l.Section @label="Components" as |s|>
-              <s.Item><a href="/button">Button</a></s.Item>
+            <l.Section @label="Components">
+              <li><a href="/button">Button</a></li>
             </l.Section>
           </NavigationList>
         </template>,
@@ -96,54 +104,52 @@ module("NavigationList", function (hooks) {
 
       assert.dom(".nvp__navigation-list__section").exists({ count: 2 });
       assert.dom(".nvp__navigation-list__label").exists({ count: 2 });
+
+      const labels = [...document.querySelectorAll(".nvp__navigation-list__label")];
+      const lists = [...document.querySelectorAll(".nvp__navigation-list__section")];
+
+      assert.notStrictEqual(labels[0]?.id, labels[1]?.id, "label ids are unique");
+      assert.strictEqual(
+        lists[0]?.getAttribute("aria-labelledby"),
+        labels[0]?.id,
+        "first list points at first label",
+      );
+      assert.strictEqual(
+        lists[1]?.getAttribute("aria-labelledby"),
+        labels[1]?.id,
+        "second list points at second label",
+      );
     });
   });
 
-  module("Item", function () {
-    test("items are list items within the section's list", async function (assert) {
+  module("items", function () {
+    test("plain <li> children are direct descendants of the section's list", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section as |s|>
-              <s.Item><a href="/a">A</a></s.Item>
-              <s.Item><a href="/b">B</a></s.Item>
+            <l.Section>
+              <li><a href="/a">A</a></li>
+              <li><a href="/b">B</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
-      assert.dom(".nvp__navigation-list__section > ul > li.nvp__navigation-list__item").exists({
-        count: 2,
-      });
+      assert.dom(".nvp__navigation-list__section > li").exists({ count: 2 });
     });
 
     test("works with plain <a> children", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section as |s|>
-              <s.Item><a href="/somewhere">Somewhere</a></s.Item>
+            <l.Section>
+              <li><a href="/somewhere">Somewhere</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
-      assert.dom(".nvp__navigation-list__item > a[href='/somewhere']").hasText("Somewhere");
-    });
-
-    test("splats attributes on the item", async function (assert) {
-      await render(
-        <template>
-          <NavigationList as |l|>
-            <l.Section as |s|>
-              <s.Item data-test-item><a href="/a">A</a></s.Item>
-            </l.Section>
-          </NavigationList>
-        </template>,
-      );
-
-      assert.dom("[data-test-item]").hasTagName("li");
-      assert.dom("[data-test-item]").hasClass("nvp__navigation-list__item");
+      assert.dom(".nvp__navigation-list__section > li > a[href='/somewhere']").hasText("Somewhere");
     });
   });
 
@@ -152,59 +158,30 @@ module("NavigationList", function (hooks) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section as |s|>
-              <s.Item><a href="/here" aria-current="page">Here</a></s.Item>
-              <s.Item><a href="/there">There</a></s.Item>
+            <l.Section>
+              <li><a href="/here" aria-current="page">Here</a></li>
+              <li><a href="/there">There</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
-      assert.dom(".nvp__navigation-list a[aria-current='page']").exists({ count: 1 });
-      assert.dom(".nvp__navigation-list a[aria-current='page']").hasText("Here");
+      assert.dom(".nvp__navigation-list li > a[aria-current='page']").exists({ count: 1 });
+      assert.dom(".nvp__navigation-list li > a[aria-current='page']").hasText("Here");
     });
 
     test("active-class links (as routers render them) are addressable", async function (assert) {
       await render(
         <template>
           <NavigationList as |l|>
-            <l.Section as |s|>
-              <s.Item><a href="/here" class="active">Here</a></s.Item>
+            <l.Section>
+              <li><a href="/here" class="active">Here</a></li>
             </l.Section>
           </NavigationList>
         </template>,
       );
 
-      assert.dom(".nvp__navigation-list a.active").exists();
-    });
-  });
-
-  module("bring your own nav (<:nav>)", function () {
-    test("renders a styling container instead of a second <nav>", async function (assert) {
-      await render(
-        <template>
-          <NavigationList data-test-container>
-            <:nav>
-              <nav aria-label="Documentation">
-                <ul>
-                  <li>
-                    Group
-                    <ul>
-                      <li><a href="/a" class="active">A</a></li>
-                      <li><a href="/b">B</a></li>
-                    </ul>
-                  </li>
-                </ul>
-              </nav>
-            </:nav>
-          </NavigationList>
-        </template>,
-      );
-
-      assert.dom("[data-test-container]").hasTagName("div");
-      assert.dom("[data-test-container]").hasClass("nvp__navigation-list");
-      assert.dom("[data-test-container] nav").exists({ count: 1 });
-      assert.dom("[data-test-container] nav a").exists({ count: 2 });
+      assert.dom(".nvp__navigation-list li > a.active").exists();
     });
   });
 });

--- a/tests/components/navigation-list-test.gts
+++ b/tests/components/navigation-list-test.gts
@@ -7,106 +7,90 @@ import { NavigationList } from "#src/index.ts";
 module("NavigationList", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("renders a nav element", async function (assert) {
+  test("is exactly a <ul>", async function (assert) {
     await render(
       <template>
-        <NavigationList as |l|>
-          <l.Section>
-            <li><a href="/a">A</a></li>
-          </l.Section>
+        <NavigationList>
+          <li><a href="/a">A</a></li>
         </NavigationList>
       </template>,
     );
 
-    assert.dom("nav.nvp__navigation-list").exists();
+    assert.dom("ul.nvp__navigation-list").exists();
+    assert.dom("ul.nvp__navigation-list").doesNotHaveAria("labelledby", "no label, no association");
+    assert.dom(".nvp__navigation-list__label").doesNotExist();
   });
 
-  test("splats attributes on the nav", async function (assert) {
+  test("splats attributes on the ul", async function (assert) {
     await render(
       <template>
-        <NavigationList aria-label="Documentation" data-test-nav as |l|>
-          <l.Section>
-            <li><a href="/a">A</a></li>
-          </l.Section>
+        <NavigationList data-test-list aria-label="Quick links">
+          <li><a href="/a">A</a></li>
         </NavigationList>
       </template>,
     );
 
-    assert.dom("[data-test-nav]").hasTagName("nav");
-    assert.dom("[data-test-nav]").hasClass("nvp__navigation-list");
-    assert.dom("[data-test-nav]").hasAria("label", "Documentation");
+    assert.dom("[data-test-list]").hasTagName("ul");
+    assert.dom("[data-test-list]").hasClass("nvp__navigation-list");
+    assert.dom("[data-test-list]").hasAria("label", "Quick links");
   });
 
-  module("Section", function () {
-    test("renders the label, associated with the list via aria-labelledby", async function (assert) {
+  test("plain <li> / <a> children are direct descendants", async function (assert) {
+    await render(
+      <template>
+        <NavigationList>
+          <li><a href="/a">A</a></li>
+          <li><a href="/somewhere">Somewhere</a></li>
+        </NavigationList>
+      </template>,
+    );
+
+    assert.dom("ul.nvp__navigation-list > li").exists({ count: 2 });
+    assert.dom("ul.nvp__navigation-list > li > a[href='/somewhere']").hasText("Somewhere");
+  });
+
+  module("@label", function () {
+    test("renders the label as a preceding sibling, associated via aria-labelledby", async function (assert) {
       await render(
         <template>
-          <NavigationList as |l|>
-            <l.Section @label="Components">
-              <li><a href="/button">Button</a></li>
-            </l.Section>
+          <NavigationList @label="Components">
+            <li><a href="/button">Button</a></li>
           </NavigationList>
         </template>,
       );
 
       assert.dom(".nvp__navigation-list__label").hasText("Components");
+      assert.dom(".nvp__navigation-list__label").hasTagName("span");
 
       const label = document.querySelector(".nvp__navigation-list__label");
-      const list = document.querySelector(".nvp__navigation-list__section");
+      const list = document.querySelector(".nvp__navigation-list");
 
       assert.ok(label?.id, "the label has an id");
+      assert.strictEqual(
+        label?.nextElementSibling,
+        list,
+        "the label immediately precedes its list (no wrapper element)",
+      );
       assert.dom(list).hasAria("labelledby", label?.id ?? "", "the list is labelled by the label");
     });
 
-    test("omits the label (and aria-labelledby) when no @label is given", async function (assert) {
+    test("multiple lists each get their own label association", async function (assert) {
       await render(
         <template>
-          <NavigationList as |l|>
-            <l.Section>
-              <li><a href="/button">Button</a></li>
-            </l.Section>
+          <NavigationList @label="Get started">
+            <li><a href="/intro">Intro</a></li>
+          </NavigationList>
+          <NavigationList @label="Components">
+            <li><a href="/button">Button</a></li>
           </NavigationList>
         </template>,
       );
 
-      assert.dom(".nvp__navigation-list__label").doesNotExist();
-      assert.dom(".nvp__navigation-list__section").doesNotHaveAria("labelledby");
-    });
-
-    test("splats attributes on the section's list", async function (assert) {
-      await render(
-        <template>
-          <NavigationList as |l|>
-            <l.Section @label="Components" data-test-section>
-              <li><a href="/button">Button</a></li>
-            </l.Section>
-          </NavigationList>
-        </template>,
-      );
-
-      assert.dom("[data-test-section]").hasTagName("ul");
-      assert.dom("[data-test-section]").hasClass("nvp__navigation-list__section");
-    });
-
-    test("supports multiple sections, each with their own label association", async function (assert) {
-      await render(
-        <template>
-          <NavigationList as |l|>
-            <l.Section @label="Get started">
-              <li><a href="/intro">Intro</a></li>
-            </l.Section>
-            <l.Section @label="Components">
-              <li><a href="/button">Button</a></li>
-            </l.Section>
-          </NavigationList>
-        </template>,
-      );
-
-      assert.dom(".nvp__navigation-list__section").exists({ count: 2 });
+      assert.dom(".nvp__navigation-list").exists({ count: 2 });
       assert.dom(".nvp__navigation-list__label").exists({ count: 2 });
 
       const labels = [...document.querySelectorAll(".nvp__navigation-list__label")];
-      const lists = [...document.querySelectorAll(".nvp__navigation-list__section")];
+      const lists = [...document.querySelectorAll(".nvp__navigation-list")];
 
       assert.notStrictEqual(labels[0]?.id, labels[1]?.id, "label ids are unique");
       assert.strictEqual(
@@ -122,46 +106,13 @@ module("NavigationList", function (hooks) {
     });
   });
 
-  module("items", function () {
-    test("plain <li> children are direct descendants of the section's list", async function (assert) {
-      await render(
-        <template>
-          <NavigationList as |l|>
-            <l.Section>
-              <li><a href="/a">A</a></li>
-              <li><a href="/b">B</a></li>
-            </l.Section>
-          </NavigationList>
-        </template>,
-      );
-
-      assert.dom(".nvp__navigation-list__section > li").exists({ count: 2 });
-    });
-
-    test("works with plain <a> children", async function (assert) {
-      await render(
-        <template>
-          <NavigationList as |l|>
-            <l.Section>
-              <li><a href="/somewhere">Somewhere</a></li>
-            </l.Section>
-          </NavigationList>
-        </template>,
-      );
-
-      assert.dom(".nvp__navigation-list__section > li > a[href='/somewhere']").hasText("Somewhere");
-    });
-  });
-
   module("current page styling hooks", function () {
     test("aria-current is preserved on consumer-rendered links", async function (assert) {
       await render(
         <template>
-          <NavigationList as |l|>
-            <l.Section>
-              <li><a href="/here" aria-current="page">Here</a></li>
-              <li><a href="/there">There</a></li>
-            </l.Section>
+          <NavigationList>
+            <li><a href="/here" aria-current="page">Here</a></li>
+            <li><a href="/there">There</a></li>
           </NavigationList>
         </template>,
       );
@@ -173,10 +124,8 @@ module("NavigationList", function (hooks) {
     test("active-class links (as routers render them) are addressable", async function (assert) {
       await render(
         <template>
-          <NavigationList as |l|>
-            <l.Section>
-              <li><a href="/here" class="active">Here</a></li>
-            </l.Section>
+          <NavigationList>
+            <li><a href="/here" class="active">Here</a></li>
           </NavigationList>
         </template>,
       );

--- a/tests/components/navigation-test.gts
+++ b/tests/components/navigation-test.gts
@@ -1,0 +1,76 @@
+import { render } from "@ember/test-helpers";
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+
+import { Navigation, NavigationList } from "#src/index.ts";
+
+module("Navigation", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("renders a nav element", async function (assert) {
+    await render(
+      <template>
+        <Navigation>
+          <NavigationList>
+            <li><a href="/a">A</a></li>
+          </NavigationList>
+        </Navigation>
+      </template>,
+    );
+
+    assert.dom("nav.nvp__navigation").exists();
+  });
+
+  test("splats attributes on the nav", async function (assert) {
+    await render(
+      <template>
+        <Navigation aria-label="Documentation" data-test-nav>
+          <NavigationList>
+            <li><a href="/a">A</a></li>
+          </NavigationList>
+        </Navigation>
+      </template>,
+    );
+
+    assert.dom("[data-test-nav]").hasTagName("nav");
+    assert.dom("[data-test-nav]").hasClass("nvp__navigation");
+    assert.dom("[data-test-nav]").hasAria("label", "Documentation");
+  });
+
+  test("contains navigation lists as direct children (no extra wrappers)", async function (assert) {
+    await render(
+      <template>
+        <Navigation aria-label="Documentation">
+          <NavigationList @label="Get started">
+            <li><a href="/intro" aria-current="page">Intro</a></li>
+          </NavigationList>
+          <NavigationList @label="Components">
+            <li><a href="/button">Button</a></li>
+          </NavigationList>
+        </Navigation>
+      </template>,
+    );
+
+    assert.dom("nav.nvp__navigation > span.nvp__navigation-list__label").exists({ count: 2 });
+    assert.dom("nav.nvp__navigation > ul.nvp__navigation-list").exists({ count: 2 });
+    assert.dom("nav.nvp__navigation a[aria-current='page']").hasText("Intro");
+  });
+
+  test("owns its own scroll behavior", async function (assert) {
+    await render(
+      <template>
+        <Navigation aria-label="Documentation">
+          <NavigationList>
+            <li><a href="/a">A</a></li>
+          </NavigationList>
+        </Navigation>
+      </template>,
+    );
+
+    const nav = document.querySelector("nav.nvp__navigation");
+    const styles = nav ? getComputedStyle(nav) : null;
+
+    assert.strictEqual(styles?.position, "sticky", "the nav is sticky");
+    assert.strictEqual(styles?.overflowY, "auto", "the nav scrolls its own overflow");
+  });
+});


### PR DESCRIPTION
Follow-up to #103, which left a fully-designed navigation list living as app-private CSS in `docs-app/docs.css`. This promotes it into the kit as **two** components, per the review direction ("should a navigation list be anything more than a `<ul>`? should the Navigation styling wrapper be a `<Navigation>`?"):

## `<NavigationList>` — exactly a labelled `<ul>`

```gjs
import { Navigation, NavigationList } from "nvp.ui";

<template>
  <Navigation aria-label="Documentation">
    <NavigationList @label="Get started">
      <li><a href="/intro" aria-current="page">Intro</a></li>
      <li><a href="/install">Installation</a></li>
    </NavigationList>
  </Navigation>
</template>
```

- **No wrapper elements.** When `@label` is passed, the label `<span>` (unique id) and the `<ul aria-labelledby>` render as *siblings* — Ember components don't need a single root, so the labelled-list pattern costs zero extra DOM. Splattributes land on the `<ul>`: the component *is* the list.
- **You bring the `<li>`s and links.** The stylesheet targets direct-descendant `li` and `li > a` structurally — plain `<a>`, `<LinkTo>`, ember-primitives links all work with zero adapter code. Current page is keyed on `a[aria-current]` (the accessible way) *and* `a.active` (what routers set).
- **Lists stack into sections by themselves**: sibling-adjacency rules (`list + label`, `list + list`) space consecutive lists apart, so a grouped nav is just several `<NavigationList @label>`s in a row.
- The label is styled text (never a heading — heading-order stays safe), announced via the list's accessible name ("Get started, list, 3 items").

## `<Navigation>` — the landmark that owns layout & responsiveness

`<nav ...attributes>` that owns its own box, independent of what renders it:

- **Sticky + scroll**: sticks `--navigation-top` (default `0px`) below the viewport top, caps its height at the remaining viewport, scrolls its own overflow.
- **Responsive** via container queries against the nearest size container: `min-width: 14rem` on wide containers, tighter padding on narrow ones (exactly what the shell's mobile tray needs).

### Navigation ↔ ApplicationShell contract

- The **shell** decides *where* navigation appears (sidebar column on wide viewports; mobile tray + hamburger on narrow ones) and sets `--navigation-top` to its sticky header's height on its layout.
- **Navigation** owns everything about its own box: stickiness, overflow, padding, width.
- The shell **no longer styles nav contents at all**: its blanket `nav ul` rules (`padding-left: 0.5rem; line-height: 1.75rem`, for both the layout and the tray) are deleted — along with the `:not(.nvp__navigation-list *)` fence that round 2 added, and the docs app's `aside.docs-nav` sticky/padding rules. Navigation/NavigationList are the single owners of nav styling.

## Kolay stays data-only

The docs sidebar and the mobile tray are `<Navigation>` + one `<NavigationList @label>` per manifest group, driven by `docsManager`/`isCollection`/`isIndex` with `aria-current` from `router.currentURL` (plain `<a href>`s, routed by `properLinks`). Same code path as the docs demos — verified by measuring computed metrics: demo, sidebar, and tray are identical on chip size/padding/radius, row gap, indent, label gap, section gap, and current-page background, in both themes. (Also fixed en route: an active-link prefix collision where `/navigation` highlighted while viewing `/navigation-list`.)

## Docs + tests

- Two docs pages (matching the one-page-per-module convention): `navigation.gjs.md` (landmark, responsiveness, shell contract) and `navigation-list.gjs.md` (labelled-ul anatomy, current-page styling, interactive `cell` demo). Both pass the axe audits in default/dark/light.
- `navigation-test.gts` + `navigation-list-test.gts`: nav rendering + splattributes + computed sticky/scroll behavior; ul-only shape (label is a *sibling*, no wrapper), `aria-labelledby` wiring with unique ids, plain `<li>`/`<a>` structure, `aria-current`/`.active` hooks.

## Verification

- `pnpm lint` — all green (types, js, hbs, format, package, published-types)
- `pnpm test` — 109/109, including every docs page's a11y audits in all three themes
- floating-deps run (`pnpm install --no-lockfile` + `pnpm test`) — 109/109
- `pnpm build` + `publint` — clean
- in-browser parity: demo == sidebar == tray computed metrics in light + dark; tray verified at 390px viewport (tight padding, no min-width)

## Other docs-only patterns that could become components (not built here)

- **Joined preview+code card** — the `.repl-sdk__demo:has(+ .repl-sdk__snippet)` rules that fuse a demo and its snippet into one card
- **Prose stack** — the typography section (h1–h4 rhythm, lede paragraph, tables, inline code) as a `Prose`/`RichText` wrapper
- **Loading spinner** — `.docs-page-loading` (with its reduced-motion handling)
- **Error callout** — `.docs-page-error` (danger-tinted alert box)
- **Feature grid** — the landing page's `docs-features` ul of `surface` cards
- **Install-command block** — `docs-hero__install`; note `src/components/install-dependency.gts` already exists but is unexported/unfinished

🤖 Generated with [Claude Code](https://claude.com/claude-code)
