### PR TITLE
Header @position="auto" (new default): move to the bottom of tall/narrow containers

### DIFF
--- a/docs-app/docs.css
+++ b/docs-app/docs.css
@@ -43,6 +43,23 @@
   border-bottom: var(--docs-border);
 }
 
+/* When @position="auto" resolves to the bottom (narrow/tall
+   containers), the hairline sits on the other side.
+   (Two rules, matching the kit's own query split -- see header.css) */
+@container (max-width: 480px) {
+  .nvp__header[data-position="auto"] {
+    border-bottom: none;
+    border-top: var(--docs-border);
+  }
+}
+
+@container (max-aspect-ratio: 1/1) {
+  .nvp__header[data-position="auto"] {
+    border-bottom: none;
+    border-top: var(--docs-border);
+  }
+}
+
 .docs-brand {
   font-size: 1.0625rem;
   font-weight: 700;

--- a/public/docs/3-components/header.gjs.md
+++ b/public/docs/3-components/header.gjs.md
@@ -1,15 +1,104 @@
 # Header
 
-The `<Header />` component provides a navigation bar for your application that can be positioned at either the top or bottom of the screen.
+The `<Header />` component provides a navigation bar for your application. By
+default (`@position="auto"`) it sticks to the top, but moves to the **bottom**
+of tall or narrow containers -- where thumbs can reach it, mobile-style. You
+can also pin it explicitly with `@position="top"` or `@position="bottom"`.
 
-This component is ideal for app navigation, offering a clean and flexible layout with left and right content areas.
+## Auto positioning
+
+Drag the frame's resize handle (bottom-right corner): make it narrow or taller
+than it is wide, and the header moves to the bottom. Widen it back out and the
+header returns to the top.
+
+```gjs live no-shadow
+import { Header } from "nvp.ui";
+
+<template>
+  <div class="resizable-app">
+    <Header>
+      <:left>
+        <strong>my-app</strong>
+      </:left>
+      <:right>
+        <a href="#home">Home</a>
+        <a href="#about">About</a>
+      </:right>
+    </Header>
+
+    <div class="fake-content">
+      <p>This frame is a
+        <code>container-type: size</code>
+        element, so the header can query both its width ("narrow") and its aspect ratio ("tall").</p>
+      <p>Resize me &#x2198;</p>
+    </div>
+  </div>
+
+  <style>
+    @scope {
+      .resizable-app {
+        /* the header queries this element */
+        container-type: size;
+
+        /* let the header re-order itself to the bottom edge */
+        display: flex;
+        flex-direction: column;
+
+        resize: both;
+        overflow: auto;
+        width: min(36rem, 100%);
+        height: 18rem;
+        min-width: 13rem;
+        min-height: 11rem;
+        max-width: 100%;
+        max-height: 38rem;
+        border: 1px solid light-dark(rgba(0, 0, 0, 0.15), rgba(255, 255, 255, 0.1));
+        border-radius: 0.5rem;
+      }
+      .fake-content {
+        flex: 1;
+        padding: 1rem;
+      }
+      .fake-content p {
+        margin: 0 0 1rem;
+        color: light-dark(#666, #aaa);
+      }
+    }
+  </style>
+</template>
+```
+
+How "auto" decides, using two container queries -- **narrow**
+(`(max-width: 480px)`) and **tall** (`(max-aspect-ratio: 1/1)`):
+
+- **narrow** works inside any container, including `<ApplicationShell>`'s
+  `inline-size` wrapper -- the docs site you are reading uses it, so this
+  site's header sits at the bottom on phones
+- **tall** (portrait aspect ratio) additionally applies inside
+  `container-type: size` elements, like the demo frame above. It is a
+  separate query on purpose: query-container selection is feature-dependent,
+  so a combined `or` query would skip `inline-size` containers entirely
+  (aspect-ratio needs size containment) and "narrow" would stop working in
+  the shell
+- with **no container ancestor** at all, `@container` rules never match
+  (there is no viewport fallback for rules), so "auto" stays at the top;
+  add a `container-type` to your layout root to opt in
+
+The bottom placement pins via `position: sticky` + flex `order`, so the
+header's parent should be a column flex (or grid) layout that fills the
+container -- `<ApplicationShell>`'s content pane is one, and the demo frame
+above shows the minimal standalone setup.
+
+## Explicit top
+
+`@position="top"` always sticks to the top, no matter the container:
 
 ```gjs live no-shadow
 import { Header } from "nvp.ui";
 
 <template>
   <div class="scroll-container">
-    <Header>
+    <Header @position="top">
       <:left>
         <a href="/">nvp.ui</a>
       </:left>
@@ -49,9 +138,10 @@ import { Header } from "nvp.ui";
 </template>
 ```
 
-## Bottom Positioning
+## Explicit bottom
 
-Use `@position="bottom"` to stick the header to the bottom. Scroll this container to see it stay anchored:
+Use `@position="bottom"` to always stick the header to the bottom. Scroll this
+container to see it stay anchored:
 
 ```gjs live no-shadow
 import { Header } from "nvp.ui";
@@ -116,9 +206,9 @@ import { ComponentSignature } from "kolay";
 
 ### State Attributes
 
-|       key       | description                                                |
-| :-------------: | :--------------------------------------------------------- |
-| `data-position` | Set to "top" or "bottom" based on the `@position` argument |
+|       key       | description                                                              |
+| :-------------: | :----------------------------------------------------------------------- |
+| `data-position` | The authored `@position`: `"auto"` (the default), `"top"`, or `"bottom"` |
 
 ### Styling
 
@@ -130,7 +220,9 @@ Public selectors:
 | `.nvp__header__left`  | Container for left-aligned content  |
 | `.nvp__header__right` | Container for right-aligned content |
 
-The header uses `position: sticky` by default with:
+The header uses `position: sticky` with:
 
-- `top: 0` for default or `@position="top"`
-- `bottom: 0` for `@position="bottom"`
+- `top: 0` for `@position="top"` (and `"auto"` on wide containers)
+- `bottom: 0` for `@position="bottom"` (and `"auto"` on narrow/tall
+  containers, which also sets flex `order: 1` so column layouts place it last)
+- the elevation shadow casts upward whenever the header sits at the bottom

--- a/src/components/application-shell.css
+++ b/src/components/application-shell.css
@@ -8,10 +8,31 @@
   container-type: inline-size;
 }
 
+/* The wrapper is `overflow: hidden` (the addon needs that for the
+   tray mechanics), which would swallow any sticky positioning inside.
+   So the shell caps the wrapper at its own box and lets the CONTENT
+   PANE own scrolling -- that is what makes sticky headers (top and
+   bottom) and the sticky sidebar nav actually pin.
+
+   (This relies on the shell being given a height, e.g. a viewport-
+   filling element around <ApplicationShell> -- without one, sticky
+   chrome degrades like any static page.) */
+.mobile-menu-wrapper.mobile-menu-wrapper {
+  height: 100%;
+}
+
 /* Double-class for higher specificity to beat the android theme.
-   Use page background instead of none so scrolling doesn't reveal gaps. */
+   Use page background instead of none so scrolling doesn't reveal gaps.
+
+   The pane is a column flex layout so that <Header @position="auto">
+   (the default) can move itself to the bottom edge on narrow
+   containers, via `order` + sticky `bottom: 0`. */
 .mobile-menu-wrapper__content.mobile-menu-wrapper__content {
   background: var(--color-page-background, #eee);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
 }
 
 .mobile-menu__tray.mobile-menu__tray {
@@ -105,6 +126,10 @@ header button.mobile-menu__toggle:active {
   display: grid;
   grid-template-columns: max-content 1fr;
   gap: 2rem;
+
+  /* Fill the content pane, so an auto-positioned bottom header
+     lands on the pane's bottom edge */
+  flex: 1;
 
   .nvp__application-shell__content {
     max-width: 100dvw;

--- a/src/components/header.css
+++ b/src/components/header.css
@@ -23,6 +23,11 @@
     bottom: 0;
   }
 
+  /* When at the bottom, the elevation shadow casts upward */
+  &[data-position="bottom"].surface {
+    --surface-elevation-shadow: var(--shadow-xl2-up);
+  }
+
   .nvp__header__left {
     display: flex;
     align-items: center;
@@ -32,5 +37,52 @@
     display: flex;
     align-items: center;
     gap: 1rem;
+  }
+}
+
+/*
+ * @position="auto" (the default): move to the bottom of tall or
+ * narrow containers -- thumb-reachable, mobile-style.
+ *
+ * "narrow" and "tall" are two SEPARATE @container rules on purpose:
+ * query-container selection is feature-dependent, so a single
+ * `(max-width) or (max-aspect-ratio)` query would skip inline-size
+ * containers entirely (aspect-ratio requires size containment) and
+ * the width half would never get a chance to match inside
+ * <ApplicationShell>'s inline-size wrapper.
+ *
+ * - "narrow" evaluates against the nearest inline-size (or size)
+ *   container -- the shell provides one;
+ * - "tall" evaluates against the nearest `container-type: size`
+ *   element (e.g. the docs' resizable demo frame);
+ * - with no container ancestor at all, @container rules never match
+ *   (no viewport fallback for rules), so "auto" degrades to "top".
+ *
+ * The `order` only takes effect when the parent is a column flex or
+ * grid layout (ApplicationShell's content pane is one) -- that is what
+ * lets `bottom: 0` stickiness actually pin to the bottom edge.
+ */
+@container (max-width: 480px) {
+  .nvp__header[data-position="auto"] {
+    top: auto;
+    bottom: 0;
+    order: 1;
+  }
+
+  .nvp__header[data-position="auto"].surface {
+    --surface-elevation-shadow: var(--shadow-xl2-up);
+  }
+}
+
+/* "tall": portrait (or square) size containers */
+@container (max-aspect-ratio: 1/1) {
+  .nvp__header[data-position="auto"] {
+    top: auto;
+    bottom: 0;
+    order: 1;
+  }
+
+  .nvp__header[data-position="auto"].surface {
+    --surface-elevation-shadow: var(--shadow-xl2-up);
   }
 }

--- a/src/components/header.gts
+++ b/src/components/header.gts
@@ -7,9 +7,25 @@ export interface Signature {
   Args: {
     /**
      * Position of the header bar.
-     * Can be "top" (default) or "bottom".
+     *
+     * - `"auto"` (default) -- sticks to the top, but moves to the
+     *   bottom of tall or narrow containers (thumb-reachable,
+     *   mobile-style), via container queries.
+     * - `"top"` -- always sticks to the top.
+     * - `"bottom"` -- always sticks to the bottom.
+     *
+     * "auto" queries the nearest size container: `<ApplicationShell>`
+     * provides an inline-size container (so "narrow" applies there),
+     * and inside a `container-type: size` element "tall" applies too.
+     * Without any container ancestor, `@container` rules never match
+     * (there is no viewport fallback for rules), so "auto" stays at
+     * the top -- add a `container-type` to your layout root to opt in.
+     *
+     * The bottom placement pins via `position: sticky` + flex `order`,
+     * so the header's parent should be a column flex (or grid) layout;
+     * `<ApplicationShell>` provides one.
      */
-    position?: "top" | "bottom";
+    position?: "auto" | "top" | "bottom";
   };
   Blocks: {
     left: [];
@@ -18,7 +34,11 @@ export interface Signature {
 }
 
 export const Header: TOC<Signature> = <template>
-  <header class="nvp__header surface elevation-xl2" data-position={{@position}} ...attributes>
+  <header
+    class="nvp__header surface elevation-xl2"
+    data-position={{if @position @position "auto"}}
+    ...attributes
+  >
     <span class="nvp__header__left">
       {{yield to="left"}}
     </span>

--- a/src/components/variables.css
+++ b/src/components/variables.css
@@ -49,6 +49,7 @@
 
   /* Shadows */
   --shadow-xl2: drop-shadow(0px 2px 1rem rgba(0, 0, 0, 0.3));
+  --shadow-xl2-up: drop-shadow(0px -2px 1rem rgba(0, 0, 0, 0.3));
   --shadow-xl: drop-shadow(0px 2px 0.75rem rgba(0, 0, 0, 0.3));
   --shadow-lg: drop-shadow(0px 2px 0.5rem rgba(0, 0, 0, 0.25));
   --shadow-md: drop-shadow(0px 2px 0.25rem rgba(0, 0, 0, 0.2));

--- a/tests/components/header-test.gts
+++ b/tests/components/header-test.gts
@@ -7,7 +7,7 @@ import { Header } from "#src/index.ts";
 module("Header", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it works with default (top) positioning", async function (assert) {
+  test("it defaults to auto positioning", async function (assert) {
     await render(
       <template>
         <Header>
@@ -25,7 +25,7 @@ module("Header", function (hooks) {
     assert.dom("header").hasClass("nvp__header");
     assert.dom("[data-test-left]").hasText("Left Content");
     assert.dom("[data-test-right]").hasText("Right Content");
-    assert.dom("header").doesNotHaveAttribute("data-position");
+    assert.dom("header").hasAttribute("data-position", "auto");
   });
 
   test("it works with top positioning", async function (assert) {
@@ -84,5 +84,111 @@ module("Header", function (hooks) {
     assert.dom(".nvp__header__right").exists();
     assert.dom(".nvp__header__left a").hasText("Home");
     assert.dom(".nvp__header__right button").hasText("Action");
+  });
+
+  module("auto positioning (container queries)", function () {
+    function headerStyles() {
+      const header = document.querySelector(".nvp__header");
+
+      if (!header) throw new Error("header not found");
+
+      const styles = getComputedStyle(header);
+
+      return { top: styles.top, bottom: styles.bottom, order: styles.order };
+    }
+
+    test("wide containers keep the header at the top", async function (assert) {
+      await render(
+        <template>
+          <div
+            style="container-type: size; width: 900px; height: 300px; display: flex; flex-direction: column;"
+          >
+            <Header>
+              <:left>wide</:left>
+            </Header>
+          </div>
+        </template>,
+      );
+
+      const { top, order } = headerStyles();
+
+      assert.strictEqual(top, "0px", "sticks to the top");
+      assert.strictEqual(order, "0", "keeps its DOM order");
+    });
+
+    test("narrow containers move the header to the bottom", async function (assert) {
+      await render(
+        <template>
+          <div
+            style="container-type: size; width: 320px; height: 480px; display: flex; flex-direction: column;"
+          >
+            <Header>
+              <:left>narrow</:left>
+            </Header>
+          </div>
+        </template>,
+      );
+
+      const { top, bottom, order } = headerStyles();
+
+      assert.strictEqual(top, "auto", "no longer pinned to the top");
+      assert.strictEqual(bottom, "0px", "sticks to the bottom");
+      assert.strictEqual(order, "1", "column layouts place it last");
+    });
+
+    test("tall (portrait) containers move the header to the bottom, even when wider than the narrow breakpoint", async function (assert) {
+      await render(
+        <template>
+          <div
+            style="container-type: size; width: 600px; height: 700px; display: flex; flex-direction: column;"
+          >
+            <Header>
+              <:left>tall</:left>
+            </Header>
+          </div>
+        </template>,
+      );
+
+      const { bottom, order } = headerStyles();
+
+      assert.strictEqual(bottom, "0px", "sticks to the bottom");
+      assert.strictEqual(order, "1", "column layouts place it last");
+    });
+
+    test("inline-size containers (like ApplicationShell's wrapper) flip on width only", async function (assert) {
+      await render(
+        <template>
+          <div style="container-type: inline-size; width: 400px;">
+            <Header>
+              <:left>narrow, width-only</:left>
+            </Header>
+          </div>
+        </template>,
+      );
+
+      const { bottom, order } = headerStyles();
+
+      assert.strictEqual(bottom, "0px", "narrow still flips without size containment");
+      assert.strictEqual(order, "1", "column layouts place it last");
+    });
+
+    test("explicit @position='top' ignores the container", async function (assert) {
+      await render(
+        <template>
+          <div
+            style="container-type: size; width: 320px; height: 480px; display: flex; flex-direction: column;"
+          >
+            <Header @position="top">
+              <:left>always top</:left>
+            </Header>
+          </div>
+        </template>,
+      );
+
+      const { top, order } = headerStyles();
+
+      assert.strictEqual(top, "0px", "stays at the top");
+      assert.strictEqual(order, "0", "keeps its DOM order");
+    });
   });
 });


### PR DESCRIPTION
Adds `@position="auto"` to `<Header>` and makes it the **new default**: on tall or narrow containers the header moves to the bottom of the screen (thumb-reachable, mobile-style); otherwise it sticks to the top. Explicit `@position="top"` / `@position="bottom"` behave exactly as before.

## The query: two separate `@container` rules, on purpose

```css
@container (max-width: 480px) { … }          /* "narrow" */
@container (max-aspect-ratio: 1/1) { … }     /* "tall"   */
```

- **narrow** evaluates against the nearest `inline-size` (or `size`) container — `<ApplicationShell>`'s wrapper is one, so the docs site gets a bottom bar on phone widths.
- **tall** (portrait/square) evaluates against the nearest `container-type: size` element — e.g. the new resizable demo frame.
- They cannot be one `(narrow) or (tall)` query: **query-container selection is feature-dependent**, so a query that mentions `aspect-ratio` skips `inline-size` containers entirely (aspect needs size containment) and the width half would never match inside the shell. A test caught this — the split is load-bearing, and commented in `header.css`.
- **No container ancestor → no flip.** Verified empirically (Chrome 150, standalone page, portrait viewport): `@container` *rules* never match without an eligible ancestor — the small-viewport fallback only exists for container *units*. So a standalone `auto` header degrades gracefully to top; add a `container-type` to your layout root to opt in. (Documented in the JSDoc and the docs page.)
- Why width-only "narrow" inside the shell: upgrading the shell's wrapper to `container-type: size` would require guaranteed definite heights from every consumer (size containment zeroes intrinsic height) — too sharp an edge for a layout element, so the shell stays `inline-size` and "tall" only applies where the consumer opts into size containment.

## Mechanism: sticky bottom + flex order (CSS-only)

The bottom state sets `top: auto; bottom: 0; order: 1` (and flips the elevation shadow to cast upward, via a new `--shadow-xl2-up` token). `order` is what lets a column flex/grid parent place the header last so `bottom: 0` stickiness lands on the container's bottom edge:

- **Inside `<ApplicationShell>`**: the shell's content pane is now a column flex layout, so the header re-orders itself to the pane's bottom.
- **Standalone**: the docs demo shows the minimal setup — a column-flex, size-contained frame. Without a column parent, `order` is inert and auto degrades to top.
- `data-position` now always renders (the authored value, defaulting to `"auto"`) as the styling/testing hook. The *resolved* mode is pure CSS (no JS/ResizeObserver), so tests assert computed placement instead of an attribute.

## Bug fix that fell out: sticky headers never actually stuck in the shell

On `main`, the header's `position: sticky` **never pinned** inside `ApplicationShell` — ember-mobile-menu's `overflow: hidden` wrapper swallows stickiness while the *body* scrolls (scroll 600px → header at `-600px`). It only looked fine because screenshots are usually taken at scroll-top. For a bottom bar to be a bottom bar, this had to be fixed: the shell now caps the wrapper at its own box (`height: 100%`) and hands scrolling to the content pane (`overflow-y: auto`). Verified in-browser: top-stuck header, bottom-stuck header, and the sticky sidebar `<Navigation>` all genuinely pin while scrolling now. (This relies on the shell being given a height — the docs' `app-root` is `100dvh`, which was clearly the intent.)

## Resizable demo

`header.gjs.md` opens with a **resizable** demo: a `resize: both` + `container-type: size` + column-flex frame. Drag the corner handle — make it narrower than 480px *or* taller than it is wide — and the header flips to the bottom live (shadow and docs hairline flip with it). Widen it back and it returns to the top. `BrowserWindow` was considered as the frame, but its own title-bar chrome competes visually with the Header and its content area isn't a size container — a minimal frame demonstrates the standalone contract better.

## Tests

- default renders `data-position="auto"`; explicit `top`/`bottom` unchanged
- computed-placement flips in fixed-size containers (CI Chrome handles container queries fine):
  - wide `size` container → top, DOM order
  - narrow `size` container → `bottom: 0`, `order: 1`
  - tall-but-not-narrow `size` container (600×700) → bottom
  - narrow `inline-size` container (the shell case) → bottom — this is the test that caught the combined-query pitfall
  - explicit `@position="top"` in a narrow/tall container → stays top

## Verification

- `pnpm lint` all green; `pnpm build` + `publint` clean
- `pnpm test` — 115/115, including every docs page's axe audits in default/dark/light
- floating-deps run (`pnpm install --no-lockfile` + tests) — 115/115
- in-browser: desktop docs site unchanged (header top, now *actually* sticky); narrow shell → pinned bottom bar with hamburger, border/shadow flipped; demo frame flips live in both drag directions and back

🤖 Generated with [Claude Code](https://claude.com/claude-code)
