### PR TITLE
Export the components' CSS so consumers can reach the tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
       "types": "./declarations/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./*.css": "./dist/components/*.css",
     "./*": {
       "types": "./declarations/components/*.d.ts",
       "default": "./dist/components/*.js"


### PR DESCRIPTION
An app that wants nvp.ui's design tokens has no supported way to get them.

`nvp.ui/variables.css` matches the `./*` pattern, so it resolves to `dist/components/variables.css.js` — a file the build never emits:

```
before: nvp.ui/variables.css -> dist/components/variables.css.js   (missing)
after:  nvp.ui/variables.css -> dist/components/variables.css      ✅
        nvp.ui/button.css    -> dist/components/button.css         ✅
        nvp.ui/button        -> dist/components/button.js          (unchanged)
```

The CSS does ship — 6.6kB of it is in the tarball. Only the exports map can't see it.

Without this, the only way to get the tokens is to import some component so its own `import "./variables.css"` runs as a side effect. That reads as an unused import, and it's exactly the kind of side effect a well-configured build is entitled to tree-shake away.

`./*.css` has a longer suffix than `./*`, so Node prefers it for `.css` subpaths and JS resolution is untouched. Every component's stylesheet becomes individually addressable as a bonus.

`publint` passes, and the full lint suite is green.

Found while wiring the tokens into [rere-benchmark's](https://github.com/NullVoxPopuli/rere-benchmark) results app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)