### PR TITLE
Menu: portal the keyboard hints; add a bare variant to Menu + Button

### DIFF
--- a/public/docs/3-components/button.gjs.md
+++ b/public/docs/3-components/button.gjs.md
@@ -26,6 +26,7 @@ const Reasoning = <template>
   <Button @variant="primary">Primary</Button>
   <Button @variant="secondary">Secondary</Button>
   <Button @variant="danger">Danger</Button>
+  <Button @variant="bare">Bare</Button>
 
   <br /><br />
 

--- a/public/docs/3-components/menu.gjs.md
+++ b/public/docs/3-components/menu.gjs.md
@@ -49,6 +49,49 @@ const noop = () => {};
 </template>
 ```
 
+## Account switcher
+
+A real-world composition: a sidebar's account switcher. The `bare`
+variant removes the trigger's button chrome so it aligns flush with
+the navigation around it, and `LinkItem` keeps switching as plain
+navigation — the current account is marked with `aria-current`.
+
+```gjs live preview no-shadow
+import { Menu, Navigation, NavigationList } from "nvp.ui";
+import { PortalTargets } from "ember-primitives";
+
+const accounts = [
+  { slug: "nullvoxp", name: "NullVoxPopuli", current: true },
+  { slug: "glimdown", name: "glimdown", current: false },
+];
+
+<template>
+  <PortalTargets />
+  <div style="max-width: 14rem;">
+    <Navigation aria-label="Example sidebar">
+      <Menu @variant="bare" as |menu|>
+        <menu.Trigger style="width: 100%" aria-label="Switch account">
+          NullVoxPopuli
+        </menu.Trigger>
+
+        <menu.Content as |Items|>
+          {{#each accounts as |account|}}
+            <Items.LinkItem @href="#{{account.slug}}" aria-current={{if account.current "true"}}>
+              {{account.name}}
+            </Items.LinkItem>
+          {{/each}}
+        </menu.Content>
+      </Menu>
+
+      <NavigationList @label="Manage">
+        <li><a href="#links">Links</a></li>
+        <li><a href="#users">Users</a></li>
+      </NavigationList>
+    </Navigation>
+  </div>
+</template>
+```
+
 ## Installation
 
 ```bash
@@ -74,9 +117,9 @@ import { ComponentSignature } from "kolay";
 
 ### State Attributes
 
-|   attribute    | values                                      | description                  |
-| :------------: | :------------------------------------------ | :--------------------------- |
-| `data-variant` | `primary`, `secondary`, `danger`, `default` | Trigger button color variant |
+|   attribute    | values                                              | description                                                     |
+| :------------: | :-------------------------------------------------- | :-------------------------------------------------------------- |
+| `data-variant` | `primary`, `secondary`, `danger`, `default`, `bare` | Trigger button color variant (`bare` removes the button chrome) |
 
 ### Styling
 

--- a/src/components/button.css
+++ b/src/components/button.css
@@ -73,6 +73,29 @@
     --button-background-color: var(--color-danger);
   }
 
+  /**
+   * No button chrome at all: reads as regular content until
+   * interacted with, and aligns flush with its surroundings.
+   */
+  &[data-variant="bare"] {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    justify-content: start;
+    text-align: left;
+
+    &:hover,
+    &:focus-visible {
+      background: color-mix(in oklab, var(--color-primary) 20%, transparent);
+      border-color: transparent;
+      box-shadow: none;
+    }
+
+    &:active {
+      background: color-mix(in oklab, var(--color-primary) 35%, transparent);
+    }
+  }
+
   &:hover {
     --button-hover-mix: 30%;
     --button-interact-spread: 1px;

--- a/src/components/button.gts
+++ b/src/components/button.gts
@@ -38,8 +38,11 @@ export interface Signature {
 
     /**
      * What colors to make the button.
+     *
+     * `bare` removes the button chrome entirely (background, border,
+     * shadow) so the button aligns flush with surrounding content.
      */
-    variant?: "danger" | "primary" | "secondary" | "default" | undefined;
+    variant?: "danger" | "primary" | "secondary" | "default" | "bare" | undefined;
 
     /**
      * Content before the button contents (such as for an icon)

--- a/src/components/menu.css
+++ b/src/components/menu.css
@@ -60,6 +60,31 @@
     --button-hover-color-mix: #000;
     --button-interact-spread: -1px;
   }
+
+  /**
+   * No button chrome at all: the trigger reads as regular content
+   * (a sidebar entry, a toolbar label) until interacted with, and
+   * aligns flush with its surroundings. Hover/press feedback matches
+   * the menu items' highlight instead of the button color math.
+   */
+  &[data-variant="bare"] {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+    justify-content: start;
+    text-align: left;
+
+    &:hover,
+    &:focus-visible {
+      background: color-mix(in oklab, var(--color-primary) 20%, transparent);
+      border-color: transparent;
+      box-shadow: none;
+    }
+
+    &:active {
+      background: color-mix(in oklab, var(--color-primary) 35%, transparent);
+    }
+  }
 }
 
 /**

--- a/src/components/menu.gts
+++ b/src/components/menu.gts
@@ -8,6 +8,8 @@ import { hash } from "@ember/helper";
 
 import { Key } from "ember-primitives/components/keys";
 import { Menu as PrimitiveMenu } from "ember-primitives/components/menu";
+import { Portal } from "ember-primitives/components/portal";
+import { TARGETS } from "ember-primitives/components/portal-targets";
 
 import type { TOC } from "@ember/component/template-only";
 import type { ComponentLike } from "@glint/template";
@@ -16,9 +18,13 @@ export interface Signature {
   Element: null;
   Args: {
     /**
-     * Color variant for the trigger button
+     * Color variant for the trigger button.
+     *
+     * `bare` removes the button chrome entirely (background, border,
+     * shadow) so the trigger can align with surrounding content —
+     * e.g. as a sidebar's account switcher.
      */
-    variant?: "primary" | "secondary" | "danger" | "default";
+    variant?: "primary" | "secondary" | "danger" | "default" | "bare";
     /**
      * Placement of the menu content relative to the trigger.
      * Uses floating-ui placement values.
@@ -88,11 +94,19 @@ const StyledContent = <template>
     }}
   </@Content>
   {{#if @isOpen}}
-    <div class="nvp__menu__kbd-hints surface elevation-lg">
-      press
-      <Key>esc</Key>
-      to close
-    </div>
+    {{! The hints anchor (CSS anchor positioning) to the portaled menu
+        content, so they must live in the same portal: rendered inline,
+        an ancestor with layout containment (e.g. a container query
+        container) would become their containing block, the anchor
+        would stop being acceptable, and the hints would land at the
+        static position instead. }}
+    <Portal @to={{TARGETS.popover}} @append={{true}}>
+      <div class="nvp__menu__kbd-hints surface elevation-lg">
+        press
+        <Key>esc</Key>
+        to close
+      </div>
+    </Portal>
   {{/if}}
 </template>;
 

--- a/tests/components/menu-test.gts
+++ b/tests/components/menu-test.gts
@@ -145,4 +145,63 @@ module("Menu", function (hooks) {
     await triggerKeyEvent(".nvp__menu__content", "keydown", "Escape");
     assert.dom(".nvp__menu__content").doesNotExist();
   });
+
+  test("@variant=bare marks the trigger", async function (assert) {
+    await render(
+      <template>
+        <PortalTargets />
+        <Menu @variant="bare" as |menu|>
+          <menu.Trigger>Accounts</menu.Trigger>
+          <menu.Content as |Items|>
+            <Items.Item>One</Items.Item>
+          </menu.Content>
+        </Menu>
+      </template>,
+    );
+
+    assert.dom(".nvp__menu__trigger").hasAttribute("data-variant", "bare");
+  });
+
+  test("the keyboard hints render inside the portal, next to the content", async function (assert) {
+    await render(
+      <template>
+        <PortalTargets />
+        <Menu as |menu|>
+          <menu.Trigger>Open</menu.Trigger>
+          <menu.Content as |Items|>
+            <Items.Item>Item 1</Items.Item>
+          </menu.Content>
+        </Menu>
+      </template>,
+    );
+
+    await click(".nvp__menu__trigger");
+
+    // Anchor positioning requires the hints and the content to share
+    // a containing block: both live in the popover portal target.
+    const portal = document.querySelector(
+      '[data-portal-name="ember-primitives__portal-targets__popover"]',
+    );
+
+    assert.dom(".nvp__menu__kbd-hints", portal).exists();
+  });
+
+  test("LinkItem renders an anchor with the given href", async function (assert) {
+    await render(
+      <template>
+        <PortalTargets />
+        <Menu as |menu|>
+          <menu.Trigger>Open</menu.Trigger>
+          <menu.Content as |Items|>
+            <Items.LinkItem @href="/somewhere">Somewhere</Items.LinkItem>
+          </menu.Content>
+        </Menu>
+      </template>,
+    );
+
+    await click(".nvp__menu__trigger");
+
+    assert.dom("a.nvp__menu__link-item").hasAttribute("href", "/somewhere");
+    assert.dom("a.nvp__menu__link-item").hasText("Somewhere");
+  });
 });


### PR DESCRIPTION
## Fix: keyboard hints escape their anchor

The \`press ESC to close\` hints use CSS anchor positioning against the portaled menu content, but rendered **inline at the trigger**. When the menu is used inside an ancestor with layout containment — e.g. a container-query container such as \`ApplicationShell\`'s sidebar — that ancestor becomes the containing block for \`position: fixed\`, the portal-rooted anchor is no longer an *acceptable anchor element*, \`anchor()\` falls back, and the hints render at the static position, clipped at the viewport edge.

Fix: render the hints into the same popover portal as the content (\`Portal @to={{TARGETS.popover}} @append={{true}}\`), restoring a shared containing block. A test pins the hints' portal location.

## Feature: \`@variant="bare"\`

\`Menu\` triggers (and \`Button\`) can now opt out of button chrome entirely — no background, border, or shadow — so a trigger reads as regular content and aligns flush with its surroundings. Hover/press feedback matches the menu items' highlight color instead of the button color math.

Motivating use: an account switcher at the top of an \`ApplicationShell\` sidebar (in the url-shortener). The Menu docs gain that exact composition as a live example: bare trigger + \`LinkItem\`s with \`aria-current\` on the active account.

## Tests

- \`@variant="bare"\` reaches \`data-variant\`
- hints render inside the popover portal target
- \`LinkItem\` renders an anchor with the given href

119 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)